### PR TITLE
feat(front): add mobile-first responsive landing page

### DIFF
--- a/BlaBlaNote/apps/front/src/pages/LandingPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/LandingPage.tsx
@@ -1,0 +1,65 @@
+import { Link } from '../router/router';
+
+const FEATURES = [
+  {
+    title: 'Capture ideas instantly',
+    description: 'Create, tag, and organize notes in seconds so your thoughts are never lost.',
+  },
+  {
+    title: 'Follow your progress',
+    description: 'Track processing status and keep important content visible with a clean dashboard.',
+  },
+  {
+    title: 'Collaborate with confidence',
+    description: 'Share notes with your team and keep everyone aligned in one workspace.',
+  },
+];
+
+export function LandingPage() {
+  return (
+    <main className="landing-page">
+      <header className="landing-header">
+        <p className="brand">BlaBlaNote</p>
+        <nav className="landing-nav" aria-label="Main navigation">
+          <Link to="/login">Sign in</Link>
+          <Link to="/register" className="nav-cta">
+            Get started
+          </Link>
+        </nav>
+      </header>
+
+      <section className="hero-section">
+        <p className="eyebrow">Notes that actually move work forward</p>
+        <h1>Turn scattered thoughts into clear, shareable knowledge.</h1>
+        <p className="hero-copy">
+          BlaBlaNote helps teams write faster, stay organized, and collaborate without switching tools.
+        </p>
+        <div className="hero-actions">
+          <Link to="/register" className="primary-link">
+            Start free
+          </Link>
+          <Link to="/login" className="secondary-link">
+            I already have an account
+          </Link>
+        </div>
+      </section>
+
+      <section className="features-section" aria-label="Product features">
+        {FEATURES.map((feature) => (
+          <article key={feature.title} className="feature-card">
+            <h2>{feature.title}</h2>
+            <p>{feature.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="cta-section">
+        <h2>Built for focused teams</h2>
+        <p>Start in minutes with a simple workflow designed for speed and clarity on every device.</p>
+        <Link to="/register" className="primary-link">
+          Create your workspace
+        </Link>
+      </section>
+    </main>
+  );
+}

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -1,5 +1,6 @@
 import { AppLayout } from '../layouts/AppLayout';
 import { DashboardPage } from '../pages/DashboardPage';
+import { LandingPage } from '../pages/LandingPage';
 import { LoginPage } from '../pages/LoginPage';
 import { NoteDetailPage } from '../pages/NoteDetailPage';
 import { NotesListPage } from '../pages/NotesListPage';
@@ -18,7 +19,11 @@ function RoutedApp() {
     return <RegisterPage />;
   }
 
-  if (path === '/' || path === '/dashboard') {
+  if (path === '/') {
+    return <LandingPage />;
+  }
+
+  if (path === '/dashboard') {
     return (
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
@@ -49,7 +54,7 @@ function RoutedApp() {
     );
   }
 
-  return <LoginPage />;
+  return <LandingPage />;
 }
 
 export function AppRouter() {

--- a/BlaBlaNote/apps/front/src/styles.css
+++ b/BlaBlaNote/apps/front/src/styles.css
@@ -212,3 +212,146 @@ button:disabled {
     transform: rotate(360deg);
   }
 }
+
+.landing-page {
+  min-height: 100vh;
+  padding: 1rem;
+  display: grid;
+  gap: 2rem;
+  background: radial-gradient(circle at top, #e0e7ff 0%, #f8fafc 45%);
+}
+
+.landing-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  font-weight: 700;
+  margin: 0;
+  font-size: 1.125rem;
+}
+
+.landing-nav {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.nav-cta,
+.secondary-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 0.875rem;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+}
+
+.hero-section {
+  max-width: 640px;
+  display: grid;
+  gap: 1rem;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #4338ca;
+  font-weight: 600;
+}
+
+.hero-section h1 {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.1;
+}
+
+.hero-copy {
+  margin: 0;
+  color: #334155;
+}
+
+.hero-actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.features-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.05);
+}
+
+.feature-card h2 {
+  margin-top: 0;
+}
+
+.feature-card p {
+  margin-bottom: 0;
+  color: #475569;
+}
+
+.cta-section {
+  background: #0f172a;
+  color: #fff;
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.875rem;
+}
+
+.cta-section h2,
+.cta-section p {
+  margin: 0;
+}
+
+.cta-section .primary-link {
+  justify-self: start;
+  background: #fff;
+  color: #0f172a;
+}
+
+@media (min-width: 768px) {
+  .landing-page {
+    padding: 2rem 4rem;
+    gap: 3rem;
+  }
+
+  .hero-section h1 {
+    font-size: 3.25rem;
+  }
+
+  .hero-actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .features-section {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .cta-section {
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    column-gap: 1.25rem;
+  }
+
+  .cta-section p {
+    grid-column: 1;
+  }
+
+  .cta-section .primary-link {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a public, modern landing page to showcase product value and streamline signup/signin flows. 
- Improve UX/UI with a simple, mobile-first responsive layout that scales to desktop breakpoints. 

### Description
- Add `LandingPage` component with header/nav, hero, feature cards, and CTA sections (`apps/front/src/pages/LandingPage.tsx`).
- Route `/` to the new landing page while preserving `/login`, `/register`, and protected app routes (`apps/front/src/router/AppRouter.tsx`).
- Implement mobile-first styles and desktop breakpoints in `apps/front/src/styles.css` to deliver a clean, modern UI and responsive layout.

### Testing
- Ran `NX_NO_CLOUD=true yarn nx build front`, which completed successfully and produced a production build.
- Ran `NX_NO_CLOUD=true yarn nx lint front`, which completed successfully with two pre-existing warnings in unrelated files (`auth.context.tsx` and `ProtectedRoute.tsx`).
- Started the dev server (`yarn nx serve front`) and validated visual output by capturing Playwright screenshots for mobile and desktop viewports, which completed successfully.
- Note: an initial `yarn nx build front` attempt reported an Nx Cloud client download issue in this environment, but the build succeeded after using `NX_NO_CLOUD=true`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fcad5da108320951d9e5afec19a0e)