### PR TITLE
feat(front): redesign authenticated home with responsive dashboard header

### DIFF
--- a/BlaBlaNote/apps/front/src/components/layout/AppHeader.tsx
+++ b/BlaBlaNote/apps/front/src/components/layout/AppHeader.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../../hooks/useAuth';
+import { Link, NavLink, usePathname } from '../../router/router';
+
+const NAV_ITEMS = [
+  { label: 'Home', to: '/home' },
+  { label: 'Notes', to: '/notes' },
+  { label: 'Create note', to: '/notes/new' },
+] as const;
+
+export function AppHeader() {
+  const pathname = usePathname();
+  const { logout, user } = useAuth();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement | null>(null);
+
+  const initials = [user?.firstName, user?.lastName]
+    .filter(Boolean)
+    .map((value) => value?.charAt(0).toUpperCase())
+    .join('')
+    .slice(0, 2);
+
+  useEffect(() => {
+    function onDocumentClick(event: MouseEvent) {
+      if (!userMenuRef.current?.contains(event.target as Node)) {
+        setUserMenuOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', onDocumentClick);
+    return () => {
+      document.removeEventListener('mousedown', onDocumentClick);
+    };
+  }, []);
+
+  useEffect(() => {
+    setMobileMenuOpen(false);
+    setUserMenuOpen(false);
+  }, [pathname]);
+
+  const sharedRouteExists = false;
+
+  return (
+    <header className="app-header">
+      <div className="app-header-inner">
+        <div className="app-header-brand">
+          <button
+            type="button"
+            className="header-menu-toggle"
+            onClick={() => setMobileMenuOpen((value) => !value)}
+            aria-label="Toggle navigation menu"
+            aria-expanded={mobileMenuOpen}
+            aria-controls="mobile-nav"
+          >
+            ☰
+          </button>
+
+          <Link to="/home" className="header-logo-link">
+            BlaBlaNote
+          </Link>
+        </div>
+
+        <nav className="header-nav" aria-label="Primary">
+          {NAV_ITEMS.map((item) => (
+            <NavLink key={item.to} to={item.to} className="header-nav-link" activeClassName="header-nav-link active">
+              {item.label}
+            </NavLink>
+          ))}
+
+          {sharedRouteExists ? (
+            <NavLink to="/shared" className="header-nav-link" activeClassName="header-nav-link active">
+              Shared
+            </NavLink>
+          ) : (
+            <span className="header-nav-link disabled" aria-disabled="true" title="Shared notes route not available yet">
+              Shared
+            </span>
+          )}
+        </nav>
+
+        <div className="user-menu" ref={userMenuRef}>
+          <button
+            type="button"
+            className="user-menu-trigger"
+            onClick={() => setUserMenuOpen((value) => !value)}
+            aria-haspopup="menu"
+            aria-expanded={userMenuOpen}
+            aria-label="Open user menu"
+          >
+            <span className="avatar-badge">{initials || 'U'}</span>
+          </button>
+
+          {userMenuOpen ? (
+            <div className="user-menu-dropdown" role="menu" aria-label="User menu">
+              <Link to="/profile" className="user-menu-item">
+                Profile
+              </Link>
+              <Link to="/settings" className="user-menu-item">
+                Settings
+              </Link>
+              <button type="button" onClick={logout} className="user-menu-item danger-item">
+                Logout
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {mobileMenuOpen ? (
+        <nav id="mobile-nav" className="mobile-nav" aria-label="Mobile primary navigation">
+          {NAV_ITEMS.map((item) => (
+            <NavLink key={item.to} to={item.to} className="mobile-nav-link" activeClassName="mobile-nav-link active">
+              {item.label}
+            </NavLink>
+          ))}
+          {sharedRouteExists ? (
+            <NavLink to="/shared" className="mobile-nav-link" activeClassName="mobile-nav-link active">
+              Shared
+            </NavLink>
+          ) : (
+            <span className="mobile-nav-link disabled" aria-disabled="true">
+              Shared (coming soon)
+            </span>
+          )}
+        </nav>
+      ) : null}
+    </header>
+  );
+}

--- a/BlaBlaNote/apps/front/src/layouts/AppLayout.tsx
+++ b/BlaBlaNote/apps/front/src/layouts/AppLayout.tsx
@@ -1,48 +1,35 @@
 import { PropsWithChildren } from 'react';
-import { NavLink } from '../router/router';
+import { AppHeader } from '../components/layout/AppHeader';
 import { useProjects } from '../hooks/useProjects';
-import { useAuth } from '../hooks/useAuth';
 import { CreateProjectForm } from '../modules/projects/CreateProjectForm';
 
 export function AppLayout({ children }: PropsWithChildren) {
   const { projects, isLoading, error, refetch } = useProjects();
-  const { logout, user } = useAuth();
 
   return (
     <div className="app-shell">
-      <aside className="sidebar">
-        <div className="sidebar-header">
-          <h1>Blabla note</h1>
-          {user && (
-            <p>
-              Welcome, {user.firstName} {user.lastName}
-            </p>
-          )}
-          <button type="button" onClick={logout}>
-            Logout
-          </button>
-        </div>
+      <AppHeader />
 
-        <nav className="sidebar-nav">
-          <NavLink to="/dashboard">Dashboard</NavLink>
-          <NavLink to="/notes">Notes</NavLink>
-        </nav>
+      <main className="content">
+        {children}
 
-        <section className="projects-list">
-          <h2>Projects</h2>
+        <section className="projects-panel" aria-label="Projects overview">
+          <div className="projects-panel-header">
+            <h2>Projects</h2>
+          </div>
+
           {isLoading ? <p>Loading projects...</p> : null}
           {error ? <p className="error-text">{error}</p> : null}
-          <ul>
+
+          <ul className="projects-items">
             {projects.map((project) => (
               <li key={project.id}>{project.name}</li>
             ))}
           </ul>
+
+          <CreateProjectForm onCreated={refetch} />
         </section>
-
-        <CreateProjectForm onCreated={refetch} />
-      </aside>
-
-      <main className="content">{children}</main>
+      </main>
     </div>
   );
 }

--- a/BlaBlaNote/apps/front/src/pages/DashboardPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/DashboardPage.tsx
@@ -1,13 +1,110 @@
-import { Link } from '../router/router';
+import { ChangeEvent, useMemo, useState } from 'react';
+import { Loader } from '../components/ui/Loader';
+import { StatusBadge } from '../components/ui/StatusBadge';
+import { useAuth } from '../hooks/useAuth';
+import { useNotes } from '../hooks/useNotes';
+import { Link, useNavigate } from '../router/router';
 
 export function DashboardPage() {
+  const { user } = useAuth();
+  const { notes, isLoading, error } = useNotes();
+  const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState('');
+
+  const filteredNotes = useMemo(() => {
+    if (!searchValue.trim()) {
+      return notes;
+    }
+
+    const normalizedValue = searchValue.toLowerCase();
+    return notes.filter((note) => {
+      const createdAt = new Date(note.createdAt).toLocaleString().toLowerCase();
+      const summary = note.summary?.toLowerCase() ?? '';
+      const translation = note.translation?.toLowerCase() ?? '';
+      return summary.includes(normalizedValue) || translation.includes(normalizedValue) || createdAt.includes(normalizedValue);
+    });
+  }, [notes, searchValue]);
+
+  const sortedNotes = useMemo(
+    () => [...filteredNotes].sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()).slice(0, 6),
+    [filteredNotes]
+  );
+
+  const hasNotes = notes.length > 0;
+
+  function onSearchChange(event: ChangeEvent<HTMLInputElement>) {
+    setSearchValue(event.target.value);
+  }
+
   return (
-    <section>
-      <h1>Dashboard</h1>
-      <p>Manage your voice notes, projects and sharing workflows.</p>
-      <Link to="/notes" className="primary-link">
-        Open notes workspace
-      </Link>
+    <section className="dashboard-page">
+      <div className="dashboard-top">
+        <div className="welcome-card">
+          <p className="welcome-eyebrow">Welcome back</p>
+          <h1>
+            {user ? `${user.firstName} ${user.lastName}` : 'Your notes dashboard'}
+          </h1>
+          <p>Capture ideas quickly, review recent recordings, and keep your note flow organized.</p>
+          <div className="welcome-actions">
+            <Link to="/notes/new" className="primary-link">
+              Create note
+            </Link>
+            <input
+              value={searchValue}
+              onChange={onSearchChange}
+              placeholder="Search notes"
+              aria-label="Search notes"
+            />
+          </div>
+        </div>
+
+        <div className="stats-grid" aria-label="Quick stats">
+          <article className="stat-card">
+            <p>Total notes</p>
+            <strong>{notes.length}</strong>
+          </article>
+          <article className="stat-card">
+            <p>Last updated</p>
+            <strong>{notes[0] ? new Date(notes[0].createdAt).toLocaleDateString() : '—'}</strong>
+          </article>
+        </div>
+      </div>
+
+      <section className="recent-notes-section">
+        <div className="section-heading">
+          <h2>Recent notes</h2>
+          <Link to="/notes" className="secondary-link">
+            View all
+          </Link>
+        </div>
+
+        {isLoading ? <Loader label="Loading notes..." /> : null}
+        {error ? <p className="error-text">{error}</p> : null}
+
+        {!isLoading && !hasNotes ? (
+          <div className="empty-state">
+            <h3>No notes yet</h3>
+            <p>Start your workspace by creating your first note.</p>
+            <Link to="/notes/new" className="primary-link">
+              Create your first note
+            </Link>
+          </div>
+        ) : null}
+
+        <ul className="notes-grid">
+          {sortedNotes.map((note) => {
+            const status = note.summary && note.translation ? 'completed' : 'processing';
+
+            return (
+              <li key={note.id} className="note-card" onClick={() => navigate(`/notes/${note.id}`)}>
+                <h3>{new Date(note.createdAt).toLocaleString()}</h3>
+                <p>{note.summary ?? 'Summary pending...'}</p>
+                <StatusBadge status={status} />
+              </li>
+            );
+          })}
+        </ul>
+      </section>
     </section>
   );
 }

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -8,6 +8,15 @@ import { RegisterPage } from '../pages/RegisterPage';
 import { ProtectedRoute } from './ProtectedRoute';
 import { matchPath, RouterProvider, usePathname } from './router';
 
+function PlaceholderPage({ title }: { title: string }) {
+  return (
+    <section>
+      <h1>{title}</h1>
+      <p>This area is coming soon.</p>
+    </section>
+  );
+}
+
 function RoutedApp() {
   const path = usePathname();
 
@@ -23,7 +32,7 @@ function RoutedApp() {
     return <LandingPage />;
   }
 
-  if (path === '/dashboard') {
+  if (path === '/dashboard' || path === '/home') {
     return (
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
@@ -33,11 +42,31 @@ function RoutedApp() {
     );
   }
 
-  if (path === '/notes') {
+  if (path === '/notes' || path === '/notes/new') {
     return (
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
           <NotesListPage />
+        </AppLayout>
+      </ProtectedRoute>
+    );
+  }
+
+  if (path === '/profile') {
+    return (
+      <ProtectedRoute redirectTo="/login">
+        <AppLayout>
+          <PlaceholderPage title="Profile" />
+        </AppLayout>
+      </ProtectedRoute>
+    );
+  }
+
+  if (path === '/settings') {
+    return (
+      <ProtectedRoute redirectTo="/login">
+        <AppLayout>
+          <PlaceholderPage title="Settings" />
         </AppLayout>
       </ProtectedRoute>
     );

--- a/BlaBlaNote/apps/front/src/styles.css
+++ b/BlaBlaNote/apps/front/src/styles.css
@@ -27,43 +27,237 @@ select {
 
 .app-shell {
   min-height: 100vh;
-  display: grid;
-  grid-template-columns: 280px 1fr;
 }
 
-.sidebar {
-  border-right: 1px solid #e2e8f0;
-  padding: 1rem;
-  background: #fff;
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  border-bottom: 1px solid #e2e8f0;
+  background: rgba(248, 250, 252, 0.9);
+  backdrop-filter: blur(8px);
+}
+
+.app-header-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  min-height: 68px;
+  padding: 0 1rem;
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
-.sidebar-header,
+.app-header-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.header-logo-link {
+  font-weight: 700;
+  font-size: 1.125rem;
+}
+
+.header-nav {
+  display: none;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.header-nav-link,
+.mobile-nav-link {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  color: #334155;
+}
+
+.header-nav-link.active,
+.mobile-nav-link.active {
+  background: #e2e8f0;
+  color: #0f172a;
+}
+
+.header-nav-link.disabled,
+.mobile-nav-link.disabled {
+  color: #94a3b8;
+  cursor: not-allowed;
+}
+
+.header-menu-toggle {
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  color: #0f172a;
+}
+
+.mobile-nav {
+  display: grid;
+  gap: 0.25rem;
+  padding: 0.625rem 1rem 0.875rem;
+  border-top: 1px solid #e2e8f0;
+  background: #fff;
+}
+
+.user-menu {
+  position: relative;
+}
+
+.user-menu-trigger {
+  background: transparent;
+  padding: 0;
+}
+
+.avatar-badge {
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #0f172a;
+  color: #fff;
+  font-weight: 600;
+}
+
+.user-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  width: 180px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  padding: 0.375rem;
+  display: grid;
+  gap: 0.125rem;
+}
+
+.user-menu-item {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border-radius: 0.5rem;
+  text-align: left;
+  border: none;
+  background: transparent;
+  color: #0f172a;
+}
+
+.user-menu-item:hover,
+.user-menu-item:focus-visible {
+  background: #f1f5f9;
+}
+
+.danger-item {
+  color: #b91c1c;
+}
+
+.content {
+  width: 100%;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1.25rem 1rem 2rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.dashboard-page {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.dashboard-top {
+  display: grid;
+  gap: 1rem;
+}
+
+.welcome-card,
+.projects-panel,
+.stat-card,
+.empty-state {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.welcome-card h1,
+.section-heading h2,
+.projects-panel-header h2 {
+  margin: 0;
+}
+
+.welcome-eyebrow {
+  margin: 0;
+  font-weight: 600;
+  color: #4338ca;
+}
+
+.welcome-card p {
+  color: #334155;
+}
+
+.welcome-actions {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.stats-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat-card p,
+.stat-card strong {
+  margin: 0;
+}
+
+.stat-card strong {
+  display: inline-block;
+  margin-top: 0.375rem;
+  font-size: 1.4rem;
+}
+
+.recent-notes-section {
+  display: grid;
+  gap: 1rem;
+}
+
+.section-heading,
+.projects-panel-header,
 .page-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
 }
 
-.sidebar-nav {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+.empty-state h3,
+.empty-state p {
+  margin: 0;
 }
 
-.sidebar-nav a {
-  padding: 0.5rem;
-  border-radius: 0.5rem;
+.empty-state {
+  display: grid;
+  gap: 0.75rem;
 }
 
-.sidebar-nav a.active {
-  background: #e2e8f0;
+.projects-items,
+.projects-list ul,
+.notes-grid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
 }
 
-.content {
-  padding: 1.5rem;
+.projects-panel {
+  display: grid;
+  gap: 0.875rem;
 }
 
 .auth-page {
@@ -113,13 +307,6 @@ button:disabled {
 
 .success-text {
   color: #15803d;
-  margin: 0;
-}
-
-.projects-list ul,
-.notes-grid {
-  list-style: none;
-  padding: 0;
   margin: 0;
 }
 
@@ -198,6 +385,8 @@ button:disabled {
 
 .primary-link {
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
   padding: 0.625rem 0.875rem;
   border-radius: 0.5rem;
   background: #0f172a;
@@ -322,6 +511,30 @@ button:disabled {
 }
 
 @media (min-width: 768px) {
+  .app-header-inner,
+  .content {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
+
+  .header-menu-toggle,
+  .mobile-nav {
+    display: none;
+  }
+
+  .header-nav {
+    display: flex;
+  }
+
+  .dashboard-top {
+    grid-template-columns: 2fr 1fr;
+  }
+
+  .welcome-actions {
+    grid-template-columns: auto minmax(220px, 1fr);
+    align-items: center;
+  }
+
   .landing-page {
     padding: 2rem 4rem;
     gap: 3rem;


### PR DESCRIPTION
### Motivation
- Improve the authenticated Home/dashboard UX by adding a sticky, responsive top header and a cleaner dashboard layout with better spacing, hierarchy and responsive behavior.
- Surface essential navigation (Home, Notes, Create note, Shared placeholder) and a compact user menu while keeping existing note/project business logic untouched.
- Provide an accessible mobile experience by collapsing nav into a hamburger menu and ensuring keyboard/aria support for menus.

### Description
- Added a new `AppHeader` component at `apps/front/src/components/layout/AppHeader.tsx` providing brand link to `/home`, desktop nav, a mobile hamburger menu, active-link state, and a user dropdown with `Profile`, `Settings`, and `Logout` (calls existing `logout`).
- Refactored `AppLayout` (`apps/front/src/layouts/AppLayout.tsx`) to use the new top header and moved the projects list / `CreateProjectForm` into a projects panel in the main content area, preserving `useProjects` logic.
- Redesigned the authenticated Home as `DashboardPage` (`apps/front/src/pages/DashboardPage.tsx`) to include a welcome block, quick actions (`Create note`), a search input (UI + wired filtering), recent notes list (reusing existing note listing and `StatusBadge`), stats cards (total notes / last updated), and a friendly empty state CTA.
- Extended router handling (`apps/front/src/router/AppRouter.tsx`) to map `/home` to the dashboard, accept `/notes/new`, and add placeholder routes for `/profile` and `/settings` used by the header.
- Updated global styles (`apps/front/src/styles.css`) to implement the sticky header, responsive layout, container max-width, improved spacing/typography, mobile nav, user-menu dropdown styles, and grid behavior for dashboard/stats/notes.

### Testing
- Built the front app with `NX_NO_CLOUD=true npx nx build front` and the build completed successfully.
- Served the front app locally with `NX_NO_CLOUD=true npx nx serve front --host=0.0.0.0 --port=4173` and verified the UI visually.
- Captured an authenticated `/home` screenshot after setting demo auth in localStorage to validate layout and interactions (screenshot produced).
- Note: an initial `npx nx build front` showed an Nx Cloud client download warning in this environment but `NX_NO_CLOUD=true` build/serve commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fd1b72d3c8320b51309f9c4c18bf5)