### PR TITLE
Implement secure auth hardening and UX flows (password reset, token rotation, terms, remember me)

### DIFF
--- a/BlaBlaNote/apps/api/prisma/migrations/20260226000100_auth_security_features/migration.sql
+++ b/BlaBlaNote/apps/api/prisma/migrations/20260226000100_auth_security_features/migration.sql
@@ -1,0 +1,30 @@
+-- AlterTable
+ALTER TABLE "User"
+ADD COLUMN "termsAcceptedAt" TIMESTAMP(3),
+ADD COLUMN "termsVersion" TEXT;
+
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "RefreshToken"
+ADD COLUMN "rememberMe" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "replacedByTokenId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_tokenHash_key" ON "PasswordResetToken"("tokenHash");
+CREATE INDEX "PasswordResetToken_userId_idx" ON "PasswordResetToken"("userId");
+CREATE INDEX "PasswordResetToken_expiresAt_idx" ON "PasswordResetToken"("expiresAt");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "RefreshToken" ADD CONSTRAINT "RefreshToken_replacedByTokenId_fkey" FOREIGN KEY ("replacedByTokenId") REFERENCES "RefreshToken"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -26,10 +26,13 @@ model User {
   email         String         @unique
   password      String
   role          Role           @default(USER)
+  termsAcceptedAt DateTime?
+  termsVersion   String?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   notes         Note[]
   refreshTokens RefreshToken[]
+  passwordResetTokens PasswordResetToken[]
 }
 
 model RefreshToken {
@@ -37,8 +40,25 @@ model RefreshToken {
   userId    String
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   tokenHash String   @unique
+  rememberMe Boolean @default(false)
+  replacedByTokenId String?
+  replacedByToken   RefreshToken? @relation("RefreshTokenRotation", fields: [replacedByTokenId], references: [id])
+  previousToken     RefreshToken[] @relation("RefreshTokenRotation")
   expiresAt DateTime
   revokedAt DateTime?
+  createdAt DateTime @default(now())
+
+  @@index([userId])
+  @@index([expiresAt])
+}
+
+model PasswordResetToken {
+  id        String   @id @default(uuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash String   @unique
+  expiresAt DateTime
+  usedAt    DateTime?
   createdAt DateTime @default(now())
 
   @@index([userId])

--- a/BlaBlaNote/apps/api/src/app/auth/auth.constants.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.constants.ts
@@ -1,4 +1,17 @@
 export const jwtConstants = {
   secret: process.env.JWT_SECRET || 'secretKey',
-  expiresIn: '1h',
+  accessExpiresIn: process.env.JWT_ACCESS_EXPIRES_IN || '15m',
+  refreshExpiresInRememberMeDays: Number(
+    process.env.JWT_REFRESH_REMEMBER_ME_DAYS || 30
+  ),
+  refreshExpiresInSessionHours: Number(
+    process.env.JWT_REFRESH_SESSION_HOURS || 24
+  ),
+  resetPasswordTokenMinutes: Number(
+    process.env.RESET_PASSWORD_TOKEN_MINUTES || 20
+  ),
+};
+
+export const cookieConstants = {
+  refreshTokenName: 'blabla_refresh_token',
 };

--- a/BlaBlaNote/apps/api/src/app/auth/auth.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.controller.ts
@@ -1,13 +1,48 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  HttpCode,
+  Ip,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { RegisterDto } from './dto/register.dto';
+import { ForgotPasswordDto } from './dto/forgot-password.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { cookieConstants } from './auth.constants';
 
 @ApiTags('Authentication')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  private getRefreshCookieOptions(expiresAt?: Date) {
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    return {
+      httpOnly: true,
+      secure: isProduction,
+      sameSite: isProduction ? ('none' as const) : ('lax' as const),
+      path: '/auth',
+      ...(expiresAt ? { expires: expiresAt } : {}),
+    };
+  }
+
+  private getCookie(req: Request, name: string) {
+    const cookieHeader = req.headers.cookie;
+    if (!cookieHeader) return undefined;
+
+    const cookies = cookieHeader.split(';').map((item) => item.trim());
+    const match = cookies.find((item) => item.startsWith(`${name}=`));
+    if (!match) return undefined;
+
+    return decodeURIComponent(match.slice(name.length + 1));
+  }
 
   @Post('register')
   @ApiOperation({ summary: 'Register a new user' })
@@ -21,7 +56,59 @@ export class AuthController {
   @ApiOperation({ summary: 'User login' })
   @ApiResponse({ status: 200 })
   @ApiResponse({ status: 401 })
-  login(@Body() dto: LoginDto) {
-    return this.authService.login(dto.email, dto.password);
+  async login(@Body() dto: LoginDto, @Res({ passthrough: true }) res: Response) {
+    const data = await this.authService.login(dto.email, dto.password, dto.rememberMe);
+
+    res.cookie(
+      cookieConstants.refreshTokenName,
+      data.refresh_token,
+      this.getRefreshCookieOptions(dto.rememberMe ? data.refresh_expires_at : undefined)
+    );
+
+    return {
+      access_token: data.access_token,
+      user: data.user,
+    };
+  }
+
+  @Post('refresh')
+  @HttpCode(200)
+  async refresh(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const refreshToken = this.getCookie(req, cookieConstants.refreshTokenName);
+    const data = await this.authService.refresh(refreshToken || '');
+
+    res.cookie(
+      cookieConstants.refreshTokenName,
+      data.refresh_token,
+      this.getRefreshCookieOptions(data.refresh_expires_at)
+    );
+
+    return { access_token: data.access_token };
+  }
+
+  @Post('logout')
+  @HttpCode(200)
+  async logout(@Req() req: Request, @Res({ passthrough: true }) res: Response) {
+    const refreshToken = this.getCookie(req, cookieConstants.refreshTokenName);
+    await this.authService.logout(refreshToken);
+
+    res.clearCookie(cookieConstants.refreshTokenName, this.getRefreshCookieOptions());
+
+    return { success: true };
+  }
+
+  @Post('forgot-password')
+  @HttpCode(200)
+  async forgotPassword(
+    @Body() dto: ForgotPasswordDto,
+    @Ip() ip: string
+  ) {
+    return this.authService.forgotPassword(dto.email, ip);
+  }
+
+  @Post('reset-password')
+  @HttpCode(200)
+  async resetPassword(@Body() dto: ResetPasswordDto) {
+    return this.authService.resetPassword(dto.token, dto.newPassword);
   }
 }

--- a/BlaBlaNote/apps/api/src/app/auth/auth.module.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { JwtStrategy } from './jwt.strategy';
 import { AuthController } from './auth.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { DiscordModule } from '../discord/discord.module';
+import { RefreshTokenService } from './refresh-token.service';
+import { MailerService } from './mailer.service';
 
 @Module({
   imports: [
@@ -16,11 +18,11 @@ import { DiscordModule } from '../discord/discord.module';
     PassportModule,
     JwtModule.register({
       secret: jwtConstants.secret,
-      signOptions: { expiresIn: jwtConstants.expiresIn },
+      signOptions: { expiresIn: jwtConstants.accessExpiresIn },
     }),
     DiscordModule,
   ],
-  providers: [AuthService, JwtStrategy],
+  providers: [AuthService, JwtStrategy, RefreshTokenService, MailerService],
   controllers: [AuthController],
   exports: [AuthService, JwtModule],
 })

--- a/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
@@ -1,27 +1,76 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
+  TooManyRequestsException,
   UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 import { PrismaService } from '../prisma/prisma.service';
 import { DiscordService } from '../discord/discord.service';
 import { RegisterDto } from './dto/register.dto';
+import { jwtConstants } from './auth.constants';
+import { RefreshTokenService } from './refresh-token.service';
+import { MailerService } from './mailer.service';
 
 @Injectable()
 export class AuthService {
+  private readonly forgotPasswordByIp = new Map<string, { count: number; resetAt: number }>();
+  private readonly forgotPasswordByEmail = new Map<string, { count: number; resetAt: number }>();
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly jwtService: JwtService,
-    private readonly discord: DiscordService
+    private readonly discord: DiscordService,
+    private readonly refreshTokenService: RefreshTokenService,
+    private readonly mailerService: MailerService
   ) {}
+
+  private generateAccessToken(user: { id: string; email: string; role: 'ADMIN' | 'USER' }) {
+    const payload = { sub: user.id, email: user.email, role: user.role };
+    return this.jwtService.sign(payload, { expiresIn: jwtConstants.accessExpiresIn });
+  }
+
+  private getRefreshExpiry(rememberMe: boolean) {
+    const now = Date.now();
+    if (rememberMe) {
+      return new Date(now + jwtConstants.refreshExpiresInRememberMeDays * 24 * 60 * 60 * 1000);
+    }
+
+    return new Date(now + jwtConstants.refreshExpiresInSessionHours * 60 * 60 * 1000);
+  }
+
+  private hitRateLimit(
+    key: string,
+    limit: number,
+    windowMs: number,
+    map: Map<string, { count: number; resetAt: number }>
+  ) {
+    const now = Date.now();
+    const current = map.get(key);
+
+    if (!current || current.resetAt <= now) {
+      map.set(key, { count: 1, resetAt: now + windowMs });
+      return;
+    }
+
+    if (current.count >= limit) {
+      throw new TooManyRequestsException('Too many requests, please retry later');
+    }
+
+    current.count += 1;
+  }
 
   async register(dto: RegisterDto) {
     const existingUser = await this.prisma.user.findUnique({
       where: { email: dto.email },
     });
     if (existingUser) throw new ConflictException('Email already in use');
+    if (!dto.termsAccepted) {
+      throw new BadRequestException('Terms must be accepted');
+    }
 
     const hashedPassword = await bcrypt.hash(dto.password, 10);
 
@@ -31,6 +80,8 @@ export class AuthService {
         lastName: dto.lastName,
         email: dto.email,
         password: hashedPassword,
+        termsAcceptedAt: new Date(),
+        termsVersion: dto.termsVersion || 'v1.0',
       },
     });
 
@@ -40,6 +91,8 @@ export class AuthService {
       firstName: user.firstName,
       lastName: user.lastName,
       role: user.role,
+      termsAcceptedAt: user.termsAcceptedAt,
+      termsVersion: user.termsVersion,
     };
   }
 
@@ -53,11 +106,18 @@ export class AuthService {
     return user;
   }
 
-  async login(email: string, password: string) {
+  async login(email: string, password: string, rememberMe = false) {
     const user = await this.validateUser(email, password);
+    const accessToken = this.generateAccessToken(user);
+    const rawRefreshToken = this.refreshTokenService.generateRawToken();
+    const refreshExpiresAt = this.getRefreshExpiry(rememberMe);
 
-    const payload = { sub: user.id, email: user.email, role: user.role };
-    const token = this.jwtService.sign(payload);
+    await this.refreshTokenService.createToken({
+      userId: user.id,
+      rawToken: rawRefreshToken,
+      expiresAt: refreshExpiresAt,
+      rememberMe,
+    });
 
     await this.discord.sendWebhook({
       username: `${user.firstName} ${user.lastName}`,
@@ -67,14 +127,127 @@ export class AuthService {
     });
 
     return {
-      access_token: token,
+      access_token: accessToken,
+      refresh_token: rawRefreshToken,
+      refresh_expires_at: refreshExpiresAt,
+      rememberMe,
       user: {
         id: user.id,
         email: user.email,
         firstName: user.firstName,
         lastName: user.lastName,
         role: user.role,
+        termsAcceptedAt: user.termsAcceptedAt,
+        termsVersion: user.termsVersion,
       },
     };
+  }
+
+  async refresh(rawRefreshToken: string) {
+    const existingToken = await this.refreshTokenService.findActiveByRawToken(rawRefreshToken);
+    if (!existingToken) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: existingToken.userId } });
+    if (!user) {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+
+    const rotated = await this.refreshTokenService.rotateToken({
+      currentTokenId: existingToken.id,
+      currentUserId: existingToken.userId,
+      rememberMe: existingToken.rememberMe,
+      expiresAt: this.getRefreshExpiry(existingToken.rememberMe),
+    });
+
+    const accessToken = this.generateAccessToken(user);
+
+    return {
+      access_token: accessToken,
+      refresh_token: rotated.newRawToken,
+      refresh_expires_at: rotated.newToken.expiresAt,
+    };
+  }
+
+  async logout(rawRefreshToken?: string) {
+    if (!rawRefreshToken) {
+      return { success: true };
+    }
+
+    const token = await this.refreshTokenService.findActiveByRawToken(rawRefreshToken);
+    if (token) {
+      await this.refreshTokenService.revokeToken(token.id);
+    }
+
+    return { success: true };
+  }
+
+  async forgotPassword(email: string, ip = 'unknown') {
+    this.hitRateLimit(ip, 5, 60_000, this.forgotPasswordByIp);
+    this.hitRateLimit(email.toLowerCase(), 3, 10 * 60_000, this.forgotPasswordByEmail);
+
+    const genericResponse = {
+      message:
+        'If your account exists, you will receive a password reset link shortly.',
+    };
+
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      return genericResponse;
+    }
+
+    const rawToken = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(rawToken).digest('hex');
+    const expiresAt = new Date(Date.now() + jwtConstants.resetPasswordTokenMinutes * 60 * 1000);
+
+    await this.prisma.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        tokenHash,
+        expiresAt,
+      },
+    });
+
+    const frontendBase = process.env.FRONTEND_URL || 'http://localhost:4201';
+    const resetLink = `${frontendBase}/reset-password?token=${rawToken}`;
+    await this.mailerService.sendPasswordResetEmail(user.email, resetLink);
+
+    return genericResponse;
+  }
+
+  async resetPassword(token: string, newPassword: string) {
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+    const resetToken = await this.prisma.passwordResetToken.findFirst({
+      where: {
+        tokenHash,
+        usedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    });
+
+    if (!resetToken) {
+      throw new BadRequestException('Invalid or expired token');
+    }
+
+    const passwordHash = await bcrypt.hash(newPassword, 10);
+
+    await this.prisma.$transaction([
+      this.prisma.user.update({
+        where: { id: resetToken.userId },
+        data: { password: passwordHash },
+      }),
+      this.prisma.passwordResetToken.update({
+        where: { id: resetToken.id },
+        data: { usedAt: new Date() },
+      }),
+      this.prisma.refreshToken.updateMany({
+        where: { userId: resetToken.userId, revokedAt: null },
+        data: { revokedAt: new Date() },
+      }),
+    ]);
+
+    return { success: true };
   }
 }

--- a/BlaBlaNote/apps/api/src/app/auth/dto/forgot-password.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/dto/forgot-password.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEmail } from 'class-validator';
+
+export class ForgotPasswordDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @IsEmail()
+  email!: string;
+}

--- a/BlaBlaNote/apps/api/src/app/auth/dto/login.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/dto/login.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
 
 export class LoginDto {
   @ApiProperty({ example: 'user@example.com' })
@@ -10,4 +10,9 @@ export class LoginDto {
   @IsString()
   @MinLength(8)
   password!: string;
+
+  @ApiPropertyOptional({ example: true })
+  @IsBoolean()
+  @IsOptional()
+  rememberMe?: boolean;
 }

--- a/BlaBlaNote/apps/api/src/app/auth/dto/register.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/dto/register.dto.ts
@@ -1,5 +1,11 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsEmail,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 export class RegisterDto {
   @ApiProperty({ example: 'John' })
@@ -18,4 +24,13 @@ export class RegisterDto {
   @IsString()
   @MinLength(8)
   password!: string;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  termsAccepted!: boolean;
+
+  @ApiPropertyOptional({ example: 'v1.0' })
+  @IsString()
+  @IsOptional()
+  termsVersion?: string;
 }

--- a/BlaBlaNote/apps/api/src/app/auth/dto/reset-password.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/dto/reset-password.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches, MinLength } from 'class-validator';
+
+export class ResetPasswordDto {
+  @ApiProperty({ example: 'raw_reset_token' })
+  @IsString()
+  @MinLength(20)
+  token!: string;
+
+  @ApiProperty({ example: 'Str0ngPass!word' })
+  @IsString()
+  @MinLength(8)
+  @Matches(/^(?=.*[A-Za-z])(?=.*\d).+$/, {
+    message: 'Password must contain letters and numbers',
+  })
+  newPassword!: string;
+}

--- a/BlaBlaNote/apps/api/src/app/auth/jwt.strategy.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/jwt.strategy.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { jwtConstants } from './auth.constants';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -8,7 +9,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: process.env.JWT_SECRET as string,
+      secretOrKey: jwtConstants.secret,
     });
   }
 

--- a/BlaBlaNote/apps/api/src/app/auth/mailer.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/mailer.service.ts
@@ -1,0 +1,11 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+@Injectable()
+export class MailerService {
+  private readonly logger = new Logger(MailerService.name);
+
+  async sendPasswordResetEmail(email: string, resetLink: string) {
+    // Plug your real provider implementation here.
+    this.logger.log(`Password reset link sent to ${email}: ${resetLink}`);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/auth/refresh-token.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/refresh-token.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class RefreshTokenService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  generateRawToken() {
+    return crypto.randomBytes(48).toString('hex');
+  }
+
+  hashToken(token: string) {
+    return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  async createToken(params: {
+    userId: string;
+    rawToken: string;
+    expiresAt: Date;
+    rememberMe: boolean;
+    replacedByTokenId?: string;
+  }) {
+    return this.prisma.refreshToken.create({
+      data: {
+        userId: params.userId,
+        tokenHash: this.hashToken(params.rawToken),
+        expiresAt: params.expiresAt,
+        rememberMe: params.rememberMe,
+        replacedByTokenId: params.replacedByTokenId,
+      },
+    });
+  }
+
+  async findActiveByRawToken(rawToken: string) {
+    const tokenHash = this.hashToken(rawToken);
+
+    return this.prisma.refreshToken.findFirst({
+      where: {
+        tokenHash,
+        revokedAt: null,
+        expiresAt: { gt: new Date() },
+      },
+    });
+  }
+
+  async revokeToken(id: string) {
+    return this.prisma.refreshToken.update({
+      where: { id },
+      data: { revokedAt: new Date() },
+    });
+  }
+
+  async rotateToken(params: {
+    currentTokenId: string;
+    currentUserId: string;
+    rememberMe: boolean;
+    expiresAt: Date;
+  }) {
+    const newRawToken = this.generateRawToken();
+    const newToken = await this.prisma.refreshToken.create({
+      data: {
+        userId: params.currentUserId,
+        tokenHash: this.hashToken(newRawToken),
+        expiresAt: params.expiresAt,
+        rememberMe: params.rememberMe,
+      },
+    });
+
+    await this.prisma.refreshToken.update({
+      where: { id: params.currentTokenId },
+      data: { revokedAt: new Date(), replacedByTokenId: newToken.id },
+    });
+
+    return { newRawToken, newToken };
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/user/dto/accept-terms.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/user/dto/accept-terms.dto.ts
@@ -1,0 +1,9 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class AcceptTermsDto {
+  @ApiPropertyOptional({ example: 'v1.0' })
+  @IsString()
+  @IsOptional()
+  termsVersion?: string;
+}

--- a/BlaBlaNote/apps/api/src/app/user/user.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/user/user.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   Put,
   Query,
+  Req,
   UseGuards,
 } from '@nestjs/common';
 import {
@@ -20,6 +21,7 @@ import { Roles } from '../auth/roles.decorator';
 import { RolesGuard } from '../auth/roles.guard';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { AcceptTermsDto } from './dto/accept-terms.dto';
 import { UserService } from './user.service';
 
 @ApiTags('Users')
@@ -39,6 +41,15 @@ export class UserController {
   })
   createUser(@Body() dto: CreateUserDto) {
     return this.userService.createUser(dto);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Post('me/accept-terms')
+  @ApiOperation({ summary: 'Accept terms and conditions' })
+  @ApiResponse({ status: 200, description: 'Terms accepted' })
+  acceptTerms(@Body() dto: AcceptTermsDto, @Req() req: { user: { id: string } }) {
+    return this.userService.acceptTerms(req.user.id, dto.termsVersion);
   }
 
   @ApiBearerAuth()

--- a/BlaBlaNote/apps/api/src/app/user/user.service.ts
+++ b/BlaBlaNote/apps/api/src/app/user/user.service.ts
@@ -51,6 +51,16 @@ export class UserService {
     });
   }
 
+
+  async acceptTerms(userId: string, termsVersion = 'v1.0') {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        termsAcceptedAt: new Date(),
+        termsVersion,
+      },
+    });
+  }
   async deleteUser(id: string) {
     const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) throw new NotFoundException('User not found');

--- a/BlaBlaNote/apps/api/src/main.ts
+++ b/BlaBlaNote/apps/api/src/main.ts
@@ -3,11 +3,12 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger } from '@nestjs/common';
+import { Logger, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import 'dotenv/config';
+
 async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle('BlaBlaNote API')
@@ -17,14 +18,24 @@ async function bootstrap() {
     .build();
 
   const app = await NestFactory.create(AppModule);
-  const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
 
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      forbidNonWhitelisted: true,
+    })
+  );
+
+  const frontendOrigin = process.env.FRONTEND_URL || 'http://localhost:4201';
   app.enableCors({
-    origin: 'http://localhost:4201',
+    origin: frontendOrigin,
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     credentials: true,
   });
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
 
   const port = process.env.PORT || 3001;
   await app.listen(port);

--- a/BlaBlaNote/apps/front/src/api/auth.api.ts
+++ b/BlaBlaNote/apps/front/src/api/auth.api.ts
@@ -4,6 +4,8 @@ import {
   LoginPayload,
   RegisterPayload,
   AuthUser,
+  ForgotPasswordPayload,
+  ResetPasswordPayload,
 } from '../types/auth.types';
 
 export const authApi = {
@@ -15,6 +17,27 @@ export const authApi = {
   register(payload: RegisterPayload) {
     return http
       .post<AuthUser>('/auth/register', payload)
+      .then((res) => res.data);
+  },
+  refresh() {
+    return http.post<{ access_token: string }>('/auth/refresh').then((res) => res.data);
+  },
+  logout() {
+    return http.post<{ success: boolean }>('/auth/logout').then((res) => res.data);
+  },
+  forgotPassword(payload: ForgotPasswordPayload) {
+    return http
+      .post<{ message: string }>('/auth/forgot-password', payload)
+      .then((res) => res.data);
+  },
+  resetPassword(payload: ResetPasswordPayload) {
+    return http
+      .post<{ success: boolean }>('/auth/reset-password', payload)
+      .then((res) => res.data);
+  },
+  acceptTerms(termsVersion = 'v1.0') {
+    return http
+      .post<AuthUser>('/users/me/accept-terms', { termsVersion })
       .then((res) => res.data);
   },
 };

--- a/BlaBlaNote/apps/front/src/api/http.ts
+++ b/BlaBlaNote/apps/front/src/api/http.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import { tokenStorage } from '../modules/auth/token.storage';
 import { ApiError } from '../types/api.types';
 
@@ -6,7 +6,15 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 export const http = axios.create({
   baseURL: API_BASE_URL,
+  withCredentials: true,
 });
+
+let refreshPromise: Promise<string> | null = null;
+let logoutHandler: (() => void) | null = null;
+
+export function registerAuthLogoutHandler(handler: () => void) {
+  logoutHandler = handler;
+}
 
 http.interceptors.request.use((config) => {
   const token = tokenStorage.getAccessToken();
@@ -18,9 +26,54 @@ http.interceptors.request.use((config) => {
   return config;
 });
 
+async function refreshAccessToken() {
+  if (!refreshPromise) {
+    refreshPromise = http
+      .post<{ access_token: string }>('/auth/refresh', null, {
+        headers: { 'x-skip-auth-retry': '1' },
+      })
+      .then((res) => {
+        tokenStorage.setAccessToken(res.data.access_token);
+        return res.data.access_token;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
+}
+
 http.interceptors.response.use(
   (response) => response,
-  (error: AxiosError) => {
+  async (error: AxiosError) => {
+    const originalConfig = (error.config || {}) as AxiosRequestConfig & {
+      _retry?: boolean;
+    };
+
+    const skipRetry = originalConfig.headers?.['x-skip-auth-retry'];
+
+    if (
+      error.response?.status === 401 &&
+      !originalConfig._retry &&
+      !skipRetry
+    ) {
+      originalConfig._retry = true;
+
+      try {
+        const token = await refreshAccessToken();
+        originalConfig.headers = {
+          ...(originalConfig.headers || {}),
+          Authorization: `Bearer ${token}`,
+        };
+
+        return http.request(originalConfig);
+      } catch {
+        tokenStorage.clearAccessToken();
+        logoutHandler?.();
+      }
+    }
+
     const responseData = error.response?.data as
       | { message?: string; statusCode?: number }
       | undefined;

--- a/BlaBlaNote/apps/front/src/modules/auth/token.storage.ts
+++ b/BlaBlaNote/apps/front/src/modules/auth/token.storage.ts
@@ -1,17 +1,18 @@
 import { AuthUser } from '../../types/auth.types';
 
-const ACCESS_TOKEN_KEY = 'blabla_note_access_token';
 const USER_KEY = 'blabla_note_user';
+
+let accessToken: string | null = null;
 
 export const tokenStorage = {
   getAccessToken(): string | null {
-    return localStorage.getItem(ACCESS_TOKEN_KEY);
+    return accessToken;
   },
   setAccessToken(token: string): void {
-    localStorage.setItem(ACCESS_TOKEN_KEY, token);
+    accessToken = token;
   },
   clearAccessToken(): void {
-    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    accessToken = null;
   },
   getUser(): AuthUser | null {
     const userJson = localStorage.getItem(USER_KEY);

--- a/BlaBlaNote/apps/front/src/pages/ForgotPasswordPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,50 @@
+import { FormEvent, useState } from 'react';
+import { authApi } from '../api/auth.api';
+import { Link } from '../router/router';
+import { ApiError } from '../types/api.types';
+
+export function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await authApi.forgotPassword({ email });
+      setMessage(response.message);
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="auth-page">
+      <form onSubmit={onSubmit} className="auth-form">
+        <h1>Forgot password</h1>
+        <input
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder="Email"
+          required
+        />
+        {message ? <p>{message}</p> : null}
+        {error ? <p className="error-text">{error}</p> : null}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Sending...' : 'Send reset link'}
+        </button>
+        <p>
+          Back to <Link to="/login">Sign in</Link>
+        </p>
+      </form>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/LoginPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/LoginPage.tsx
@@ -8,6 +8,7 @@ export function LoginPage() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [rememberMe, setRememberMe] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -17,7 +18,7 @@ export function LoginPage() {
     setIsSubmitting(true);
 
     try {
-      await login({ email, password });
+      await login({ email, password, rememberMe });
       navigate('/dashboard');
     } catch (err) {
       setError((err as ApiError).message);
@@ -44,10 +45,21 @@ export function LoginPage() {
           placeholder="Password"
           required
         />
+        <label>
+          <input
+            type="checkbox"
+            checked={rememberMe}
+            onChange={(event) => setRememberMe(event.target.checked)}
+          />{' '}
+          Remember me
+        </label>
         {error ? <p className="error-text">{error}</p> : null}
         <button type="submit" disabled={isSubmitting}>
           {isSubmitting ? 'Signing in...' : 'Sign in'}
         </button>
+        <p>
+          <Link to="/forgot-password">Forgot password?</Link>
+        </p>
         <p>
           No account? <Link to="/register">Create one</Link>
         </p>

--- a/BlaBlaNote/apps/front/src/pages/RegisterPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/RegisterPage.tsx
@@ -10,6 +10,7 @@ export function RegisterPage() {
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [termsAccepted, setTermsAccepted] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,7 +20,14 @@ export function RegisterPage() {
     setIsSubmitting(true);
 
     try {
-      await register({ firstName, lastName, email, password });
+      await register({
+        firstName,
+        lastName,
+        email,
+        password,
+        termsAccepted,
+        termsVersion: 'v1.0',
+      });
       navigate('/dashboard');
     } catch (err) {
       setError((err as ApiError).message);
@@ -42,8 +50,17 @@ export function RegisterPage() {
           placeholder="Password"
           required
         />
+        <label>
+          <input
+            type="checkbox"
+            checked={termsAccepted}
+            onChange={(event) => setTermsAccepted(event.target.checked)}
+            required
+          />{' '}
+          I accept the <Link to="/terms">Terms & Conditions</Link>
+        </label>
         {error ? <p className="error-text">{error}</p> : null}
-        <button type="submit" disabled={isSubmitting}>
+        <button type="submit" disabled={isSubmitting || !termsAccepted}>
           {isSubmitting ? 'Creating account...' : 'Create account'}
         </button>
         <p>

--- a/BlaBlaNote/apps/front/src/pages/ResetPasswordPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,73 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { authApi } from '../api/auth.api';
+import { Link } from '../router/router';
+import { ApiError } from '../types/api.types';
+
+export function ResetPasswordPage() {
+  const token = useMemo(
+    () => new URLSearchParams(window.location.search).get('token') || '',
+    []
+  );
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    if (!token) {
+      setError('Missing token. Please use the reset link from your email.');
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError('Passwords do not match.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await authApi.resetPassword({ token, newPassword });
+      setMessage('Password reset successful. You can now sign in.');
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="auth-page">
+      <form onSubmit={onSubmit} className="auth-form">
+        <h1>Reset password</h1>
+        <input
+          type="password"
+          value={newPassword}
+          onChange={(event) => setNewPassword(event.target.value)}
+          placeholder="New password"
+          required
+        />
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(event) => setConfirmPassword(event.target.value)}
+          placeholder="Confirm password"
+          required
+        />
+        {message ? <p>{message}</p> : null}
+        {error ? <p className="error-text">{error}</p> : null}
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Resetting...' : 'Reset password'}
+        </button>
+        <p>
+          Back to <Link to="/login">Sign in</Link>
+        </p>
+      </form>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/TermsConsentPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/TermsConsentPage.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { authApi } from '../api/auth.api';
+import { useAuth } from '../hooks/useAuth';
+import { useNavigate } from '../router/router';
+
+export function TermsConsentPage() {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [accepted, setAccepted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function onAccept() {
+    if (!accepted || isSubmitting) return;
+
+    setIsSubmitting(true);
+    try {
+      await authApi.acceptTerms('v1.0');
+      navigate('/dashboard', { replace: true });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="auth-page">
+      <div className="auth-form">
+        <h1>Accept Terms</h1>
+        <p>
+          Welcome {user?.firstName}. You need to accept the latest terms to continue.
+        </p>
+        <label>
+          <input
+            type="checkbox"
+            checked={accepted}
+            onChange={(event) => setAccepted(event.target.checked)}
+          />{' '}
+          I accept the Terms & Conditions (v1.0)
+        </label>
+        <button type="button" disabled={!accepted || isSubmitting} onClick={onAccept}>
+          {isSubmitting ? 'Saving...' : 'Continue'}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/TermsPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/TermsPage.tsx
@@ -1,0 +1,13 @@
+export function TermsPage() {
+  return (
+    <section className="auth-page">
+      <article className="auth-form">
+        <h1>Conditions générales</h1>
+        <p>
+          Placeholder terms content. Replace with legal-approved text and keep a
+          version history (e.g. v1.0).
+        </p>
+      </article>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -7,6 +7,10 @@ import { NotesListPage } from '../pages/NotesListPage';
 import { RegisterPage } from '../pages/RegisterPage';
 import { ProtectedRoute } from './ProtectedRoute';
 import { matchPath, RouterProvider, usePathname } from './router';
+import { ForgotPasswordPage } from '../pages/ForgotPasswordPage';
+import { ResetPasswordPage } from '../pages/ResetPasswordPage';
+import { TermsPage } from '../pages/TermsPage';
+import { TermsConsentPage } from '../pages/TermsConsentPage';
 
 function PlaceholderPage({ title }: { title: string }) {
   return (
@@ -26,6 +30,26 @@ function RoutedApp() {
 
   if (path === '/register') {
     return <RegisterPage />;
+  }
+
+  if (path === '/forgot-password') {
+    return <ForgotPasswordPage />;
+  }
+
+  if (path === '/reset-password') {
+    return <ResetPasswordPage />;
+  }
+
+  if (path === '/terms') {
+    return <TermsPage />;
+  }
+
+  if (path === '/terms-consent') {
+    return (
+      <ProtectedRoute redirectTo="/login">
+        <TermsConsentPage />
+      </ProtectedRoute>
+    );
   }
 
   if (path === '/') {

--- a/BlaBlaNote/apps/front/src/router/ProtectedRoute.tsx
+++ b/BlaBlaNote/apps/front/src/router/ProtectedRoute.tsx
@@ -1,21 +1,32 @@
 import { PropsWithChildren, useEffect } from 'react';
 import { Loader } from '../components/ui/Loader';
 import { useAuth } from '../hooks/useAuth';
-import { useNavigate } from './router';
+import { useNavigate, usePathname } from './router';
 
 interface ProtectedRouteProps extends PropsWithChildren {
   redirectTo: string;
 }
 
 export function ProtectedRoute({ children, redirectTo }: ProtectedRouteProps) {
-  const { isAuthenticated, isLoading } = useAuth();
+  const { isAuthenticated, isLoading, user } = useAuth();
   const navigate = useNavigate();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
       navigate(redirectTo, { replace: true });
+      return;
     }
-  }, [isAuthenticated, isLoading, navigate, redirectTo]);
+
+    if (
+      !isLoading &&
+      isAuthenticated &&
+      !user?.termsAcceptedAt &&
+      pathname !== '/terms-consent'
+    ) {
+      navigate('/terms-consent', { replace: true });
+    }
+  }, [isAuthenticated, isLoading, navigate, pathname, redirectTo, user?.termsAcceptedAt]);
 
   if (isLoading || !isAuthenticated) {
     return <Loader label="Checking session..." />;

--- a/BlaBlaNote/apps/front/src/types/auth.types.ts
+++ b/BlaBlaNote/apps/front/src/types/auth.types.ts
@@ -1,6 +1,7 @@
 export interface LoginPayload {
   email: string;
   password: string;
+  rememberMe?: boolean;
 }
 
 export interface RegisterPayload {
@@ -8,6 +9,8 @@ export interface RegisterPayload {
   lastName: string;
   email: string;
   password: string;
+  termsAccepted: boolean;
+  termsVersion?: string;
 }
 
 export interface AuthTokenResponse {
@@ -21,4 +24,15 @@ export interface AuthUser {
   lastName: string;
   email: string;
   role: 'USER' | 'ADMIN';
+  termsAcceptedAt?: string | null;
+  termsVersion?: string | null;
+}
+
+export interface ForgotPasswordPayload {
+  email: string;
+}
+
+export interface ResetPasswordPayload {
+  token: string;
+  newPassword: string;
 }


### PR DESCRIPTION
### Motivation
- Add robust, production-grade authentication flows: secure forgot/reset-password, refresh-token rotation with cookie-based refresh, and `remember me` semantics to improve usability while preserving security.  
- Enforce Terms & Conditions acceptance in the signup flow and provide a post-login consent gate for existing users.  
- Reduce client-side token exposure by keeping access tokens in memory and using HttpOnly cookies for refresh tokens, plus one-time hashed reset tokens and rotation to mitigate replay/XSS risks.

### Description
- Database and schema: added `PasswordResetToken` model, `termsAcceptedAt`/`termsVersion` on `User`, and refresh-token rotation fields (`rememberMe`, `replacedByTokenId`) with a Prisma migration SQL file and schema changes (see `apps/api/prisma/schema.prisma` and migration).  
- Backend (NestJS): added/updated controllers, DTOs and services: `POST /auth/forgot-password`, `POST /auth/reset-password`, `POST /auth/refresh`, `POST /auth/logout`, and extended `POST /auth/login` to accept `rememberMe` and set cookie options; implemented secure token generation + hashed storage, expiry, one-time use (`usedAt`), token rotation and revocation logic in `auth.service.ts` and `refresh-token.service.ts`, plus a `mailer.service.ts` abstraction and rate-limit buckets for `forgot-password`.  
- Backend infra: global `ValidationPipe` and credential-ready CORS in `main.ts`, and JWT/cookie constants in `auth.constants.ts`.  
- Frontend (React/TypeScript): moved access token to in-memory storage (`token.storage.ts`) while persisting user profile to `localStorage`; HTTP client uses `withCredentials: true`, implements single-flight refresh dedupe and automatic retry-once on 401 (`http.ts`), and registers a logout handler.  
- UX/routes: added pages and routes for `/forgot-password`, `/reset-password`, `/terms`, and a `/terms-consent` gate; updated `Login` with a `Remember me` checkbox and `Register` to require a Terms checkbox (submit disabled until accepted).  
- DTOs/validation: strengthened DTOs for login/register/reset flows (password rules), and added an endpoint `POST /users/me/accept-terms` to capture post-login acceptance.  

### Testing
- Dependency install: attempted `yarn install --frozen-lockfile` but it failed due to environment network/registry restrictions (tunneling/proxy 403), so dependencies could not be installed in CI-environment (failed).  
- Build: attempted `yarn nx run api:build` but failed because dependencies/`nx` were not available in the environment (failed).  
- End-to-end smoke: attempted an automated Playwright page access to `http://localhost:4201/login` to capture screenshots, but the app was not running in this environment so navigation failed (failed).  
- Notes: no unit/integration tests were executed due to the above constraints; the code includes validation and DTOs for server-side checks and a Prisma migration SQL file; please run `yarn prisma:migrate` then `yarn` and `yarn nx run api:build` locally or in CI to validate and run tests, and replace the `MailerService` stub with your provider for email delivery in staging/production.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fdfe39a2c83209d478b78eb39654c)