### PR TITLE
feat(admin): add secure admin users management list

### DIFF
--- a/BlaBlaNote/apps/api/prisma/migrations/20260227000000_admin_users_status/migration.sql
+++ b/BlaBlaNote/apps/api/prisma/migrations/20260227000000_admin_users_status/migration.sql
@@ -1,0 +1,13 @@
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('ACTIVE', 'SUSPENDED', 'PENDING', 'DELETED');
+
+-- AlterTable
+ALTER TABLE "User"
+ADD COLUMN "status" "UserStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN "lastLoginAt" TIMESTAMP(3),
+ADD COLUMN "suspendedAt" TIMESTAMP(3),
+ADD COLUMN "deletedAt" TIMESTAMP(3),
+ADD COLUMN "plan" TEXT,
+ADD COLUMN "priceCents" INTEGER,
+ADD COLUMN "currency" TEXT,
+ADD COLUMN "billingStatus" TEXT;

--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -26,8 +26,16 @@ model User {
   email         String         @unique
   password      String
   role          Role           @default(USER)
+  status        UserStatus     @default(PENDING)
   termsAcceptedAt DateTime?
   termsVersion   String?
+  lastLoginAt   DateTime?
+  suspendedAt   DateTime?
+  deletedAt     DateTime?
+  plan          String?
+  priceCents    Int?
+  currency      String?
+  billingStatus String?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   notes         Note[]
@@ -68,4 +76,11 @@ model PasswordResetToken {
 enum Role {
   USER
   ADMIN
+}
+
+enum UserStatus {
+  ACTIVE
+  SUSPENDED
+  PENDING
+  DELETED
 }

--- a/BlaBlaNote/apps/api/src/app/admin/admin.module.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/admin.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AdminUsersController } from './users.controller';
+import { AdminUsersService } from './users.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AdminUsersController],
+  providers: [AdminUsersService],
+})
+export class AdminModule {}

--- a/BlaBlaNote/apps/api/src/app/admin/dto/get-admin-users-query.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/dto/get-admin-users-query.dto.ts
@@ -1,0 +1,130 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsArray,
+  IsBoolean,
+  IsDateString,
+  IsEnum,
+  IsIn,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+
+const ALLOWED_SORT_FIELDS = [
+  'createdAt',
+  'lastLoginAt',
+  'email',
+  'price',
+  'notesCount',
+] as const;
+
+export type AdminUsersSortField = (typeof ALLOWED_SORT_FIELDS)[number];
+
+function parseNumber(value: unknown, defaultValue: number) {
+  if (value === undefined || value === null || value === '') {
+    return defaultValue;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : value;
+}
+
+function parseBoolean(value: unknown) {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') return true;
+    if (value.toLowerCase() === 'false') return false;
+  }
+
+  return value;
+}
+
+function parseStatusArray(value: unknown) {
+  if (!value) return undefined;
+
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return value;
+}
+
+export class GetAdminUsersQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @Transform(({ value }) => parseNumber(value, 1))
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page = 1;
+
+  @ApiPropertyOptional({ default: 20, maximum: 100 })
+  @Transform(({ value }) => parseNumber(value, 20))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  pageSize = 20;
+
+  @ApiPropertyOptional({ description: 'Search by firstName, lastName or email' })
+  @IsString()
+  @IsOptional()
+  search?: string;
+
+  @ApiPropertyOptional({
+    enum: ['ACTIVE', 'SUSPENDED', 'PENDING', 'DELETED'],
+    isArray: true,
+  })
+  @Transform(({ value }) => parseStatusArray(value))
+  @IsArray()
+  @IsEnum(['ACTIVE', 'SUSPENDED', 'PENDING', 'DELETED'], { each: true })
+  @IsOptional()
+  status?: Array<'ACTIVE' | 'SUSPENDED' | 'PENDING' | 'DELETED'>;
+
+  @ApiPropertyOptional({ enum: ['ADMIN', 'USER'] })
+  @IsEnum(['ADMIN', 'USER'])
+  @IsOptional()
+  role?: 'ADMIN' | 'USER';
+
+  @ApiPropertyOptional()
+  @Transform(({ value }) => parseBoolean(value))
+  @IsBoolean()
+  @IsOptional()
+  hasActiveRefreshTokens?: boolean;
+
+  @ApiPropertyOptional()
+  @IsDateString()
+  @IsOptional()
+  createdFrom?: string;
+
+  @ApiPropertyOptional()
+  @IsDateString()
+  @IsOptional()
+  createdTo?: string;
+
+  @ApiPropertyOptional({ enum: ALLOWED_SORT_FIELDS, default: 'createdAt' })
+  @IsIn(ALLOWED_SORT_FIELDS)
+  @IsOptional()
+  sortBy: AdminUsersSortField = 'createdAt';
+
+  @ApiPropertyOptional({ enum: ['asc', 'desc'], default: 'desc' })
+  @IsEnum(['asc', 'desc'])
+  @IsOptional()
+  sortDir: 'asc' | 'desc' = 'desc';
+}

--- a/BlaBlaNote/apps/api/src/app/admin/users.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/users.controller.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { GetAdminUsersQueryDto } from './dto/get-admin-users-query.dto';
+import { AdminUsersService } from './users.service';
+
+@ApiTags('Admin Users')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+@Controller('admin/users')
+export class AdminUsersController {
+  constructor(private readonly adminUsersService: AdminUsersService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get paginated users list (Admin only)' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    isArray: true,
+    enum: ['ACTIVE', 'SUSPENDED', 'PENDING', 'DELETED'],
+  })
+  @ApiQuery({ name: 'role', required: false, enum: ['ADMIN', 'USER'] })
+  @ApiQuery({ name: 'hasActiveRefreshTokens', required: false, type: Boolean })
+  @ApiQuery({ name: 'createdFrom', required: false, type: String })
+  @ApiQuery({ name: 'createdTo', required: false, type: String })
+  @ApiQuery({
+    name: 'sortBy',
+    required: false,
+    enum: ['createdAt', 'lastLoginAt', 'email', 'price', 'notesCount'],
+  })
+  @ApiQuery({ name: 'sortDir', required: false, enum: ['asc', 'desc'] })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated users list with safe token metadata',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin only' })
+  getUsers(@Query() query: GetAdminUsersQueryDto) {
+    return this.adminUsersService.getUsers(query);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/admin/users.service.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/users.service.ts
@@ -1,0 +1,192 @@
+import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { GetAdminUsersQueryDto } from './dto/get-admin-users-query.dto';
+
+@Injectable()
+export class AdminUsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getUsers(query: GetAdminUsersQueryDto) {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 20;
+    const skip = (page - 1) * pageSize;
+    const now = new Date();
+
+    const where: Prisma.UserWhereInput = {
+      ...(query.search
+        ? {
+            OR: [
+              {
+                email: {
+                  contains: query.search,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                firstName: {
+                  contains: query.search,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                lastName: {
+                  contains: query.search,
+                  mode: 'insensitive',
+                },
+              },
+            ],
+          }
+        : {}),
+      ...(query.status?.length ? { status: { in: query.status } } : {}),
+      ...(query.role ? { role: query.role } : {}),
+      ...(query.createdFrom || query.createdTo
+        ? {
+            createdAt: {
+              ...(query.createdFrom ? { gte: new Date(query.createdFrom) } : {}),
+              ...(query.createdTo ? { lte: new Date(query.createdTo) } : {}),
+            },
+          }
+        : {}),
+      ...(query.hasActiveRefreshTokens === true
+        ? {
+            refreshTokens: {
+              some: {
+                revokedAt: null,
+                expiresAt: { gt: now },
+              },
+            },
+          }
+        : {}),
+      ...(query.hasActiveRefreshTokens === false
+        ? {
+            refreshTokens: {
+              none: {
+                revokedAt: null,
+                expiresAt: { gt: now },
+              },
+            },
+          }
+        : {}),
+    };
+
+    const orderBy = this.buildOrderBy(query.sortBy, query.sortDir);
+
+    const [total, users] = await this.prisma.$transaction([
+      this.prisma.user.count({ where }),
+      this.prisma.user.findMany({
+        where,
+        skip,
+        take: pageSize,
+        orderBy,
+        select: {
+          id: true,
+          firstName: true,
+          lastName: true,
+          email: true,
+          role: true,
+          status: true,
+          createdAt: true,
+          updatedAt: true,
+          lastLoginAt: true,
+          plan: true,
+          priceCents: true,
+          currency: true,
+          billingStatus: true,
+          termsAcceptedAt: true,
+          termsVersion: true,
+          _count: {
+            select: {
+              notes: true,
+            },
+          },
+          refreshTokens: {
+            where: {
+              revokedAt: null,
+              expiresAt: { gt: now },
+            },
+            select: {
+              createdAt: true,
+              expiresAt: true,
+            },
+          },
+        },
+      }),
+    ]);
+
+    const items = users.map((user) => {
+      const lastIssuedAt =
+        user.refreshTokens.length > 0
+          ? new Date(
+              Math.max(
+                ...user.refreshTokens.map((refreshToken) =>
+                  refreshToken.createdAt.getTime()
+                )
+              )
+            )
+          : null;
+
+      const maxExpiresAt =
+        user.refreshTokens.length > 0
+          ? new Date(
+              Math.max(
+                ...user.refreshTokens.map((refreshToken) =>
+                  refreshToken.expiresAt.getTime()
+                )
+              )
+            )
+          : null;
+
+      return {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        role: user.role,
+        status: user.status,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+        lastLoginAt: user.lastLoginAt,
+        notesCount: user._count.notes,
+        plan: user.plan,
+        priceCents: user.priceCents,
+        currency: user.currency,
+        billingStatus: user.billingStatus,
+        refreshTokens: {
+          activeCount: user.refreshTokens.length,
+          lastIssuedAt,
+          maxExpiresAt,
+        },
+        termsAcceptedAt: user.termsAcceptedAt,
+        termsVersion: user.termsVersion,
+      };
+    });
+
+    return {
+      items,
+      page,
+      pageSize,
+      total,
+    };
+  }
+
+  private buildOrderBy(sortBy: string, sortDir: 'asc' | 'desc'): Prisma.UserOrderByWithRelationInput | Prisma.UserOrderByWithRelationInput[] {
+    if (sortBy === 'notesCount') {
+      return {
+        notes: {
+          _count: sortDir,
+        },
+      };
+    }
+
+    if (sortBy === 'price') {
+      return {
+        priceCents: sortDir,
+      };
+    }
+
+    return {
+      [sortBy]: sortDir,
+    };
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/app.module.ts
+++ b/BlaBlaNote/apps/api/src/app/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from './auth/auth.module';
 import { NoteModule } from './note/note.module';
 import { WhisperModule } from './whisper/whisper.module';
 import { DiscordModule } from './discord/discord.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { DiscordModule } from './discord/discord.module';
     NoteModule,
     WhisperModule,
     DiscordModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
@@ -129,6 +129,12 @@ export class AuthService {
 
   async login(email: string, password: string, rememberMe = false) {
     const user = await this.validateUser(email, password);
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: { lastLoginAt: new Date() },
+    });
+
     const accessToken = this.generateAccessToken(user);
     const rawRefreshToken = this.refreshTokenService.generateRawToken();
     const refreshExpiresAt = this.getRefreshExpiry(rememberMe);

--- a/BlaBlaNote/apps/front/src/api/adminUsers.api.ts
+++ b/BlaBlaNote/apps/front/src/api/adminUsers.api.ts
@@ -1,0 +1,32 @@
+import { http } from './http';
+import { AdminUsersQuery, AdminUsersResponse } from '../types/admin-users.types';
+
+function buildParams(query: AdminUsersQuery) {
+  const params = new URLSearchParams();
+
+  if (query.page) params.set('page', String(query.page));
+  if (query.pageSize) params.set('pageSize', String(query.pageSize));
+  if (query.search) params.set('search', query.search);
+  if (query.role) params.set('role', query.role);
+  if (query.createdFrom) params.set('createdFrom', query.createdFrom);
+  if (query.createdTo) params.set('createdTo', query.createdTo);
+  if (typeof query.hasActiveRefreshTokens === 'boolean') {
+    params.set('hasActiveRefreshTokens', String(query.hasActiveRefreshTokens));
+  }
+  if (query.sortBy) params.set('sortBy', query.sortBy);
+  if (query.sortDir) params.set('sortDir', query.sortDir);
+
+  query.status?.forEach((status) => params.append('status', status));
+
+  return params;
+}
+
+export const adminUsersApi = {
+  getUsers(query: AdminUsersQuery) {
+    const params = buildParams(query);
+
+    return http
+      .get<AdminUsersResponse>(`/admin/users?${params.toString()}`)
+      .then((res) => res.data);
+  },
+};

--- a/BlaBlaNote/apps/front/src/pages/AdminUsersPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/AdminUsersPage.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useMemo, useState } from 'react';
+import { adminUsersApi } from '../api/adminUsers.api';
+import {
+  AdminUserItem,
+  AdminUsersQuery,
+  UserRole,
+  UserStatus,
+} from '../types/admin-users.types';
+
+const USER_STATUSES: UserStatus[] = ['ACTIVE', 'SUSPENDED', 'PENDING', 'DELETED'];
+const SORT_FIELDS: AdminUsersQuery['sortBy'][] = [
+  'createdAt',
+  'lastLoginAt',
+  'email',
+  'price',
+  'notesCount',
+];
+
+function formatDate(value?: string | null) {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
+}
+
+function formatPrice(priceCents?: number | null, currency?: string | null) {
+  if (priceCents === null || priceCents === undefined) return '—';
+  const code = currency || 'USD';
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: code,
+  }).format(priceCents / 100);
+}
+
+export function AdminUsersPage() {
+  const [items, setItems] = useState<AdminUserItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [query, setQuery] = useState<AdminUsersQuery>({
+    page: 1,
+    pageSize: 20,
+    sortBy: 'createdAt',
+    sortDir: 'desc',
+    status: [],
+  });
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    adminUsersApi
+      .getUsers(query)
+      .then((response) => {
+        setItems(response.items);
+        setTotal(response.total);
+      })
+      .catch((apiError: { message?: string }) => {
+        setError(apiError.message ?? 'Failed to load users.');
+      })
+      .finally(() => setLoading(false));
+  }, [query]);
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(total / (query.pageSize || 20))),
+    [query.pageSize, total]
+  );
+
+  const setPartialQuery = (next: Partial<AdminUsersQuery>) => {
+    setQuery((prev) => ({ ...prev, ...next, page: 1 }));
+  };
+
+  const toggleStatus = (status: UserStatus) => {
+    const current = query.status ?? [];
+    const exists = current.includes(status);
+    const nextStatuses = exists
+      ? current.filter((item) => item !== status)
+      : [...current, status];
+
+    setPartialQuery({ status: nextStatuses });
+  };
+
+  const clearFilters = () => {
+    setQuery({
+      page: 1,
+      pageSize: query.pageSize,
+      sortBy: query.sortBy,
+      sortDir: query.sortDir,
+      status: [],
+    });
+  };
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-slate-900">Users</h1>
+        <p className="text-sm text-slate-600">Admin-only user management and token metadata.</p>
+      </div>
+
+      <form className="grid gap-4 rounded-xl border border-slate-200 bg-white p-4 md:grid-cols-2 xl:grid-cols-4" onSubmit={(e) => e.preventDefault()} aria-label="Users filters">
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Search</span>
+          <input
+            type="text"
+            value={query.search ?? ''}
+            onChange={(e) => setPartialQuery({ search: e.target.value || undefined })}
+            placeholder="Email, first name, last name"
+            className="rounded-lg border border-slate-300 px-3 py-2"
+          />
+        </label>
+
+        <fieldset className="flex flex-col gap-1 text-sm">
+          <legend className="font-medium text-slate-700">Status</legend>
+          <div className="flex flex-wrap gap-2">
+            {USER_STATUSES.map((status) => (
+              <label key={status} className="inline-flex items-center gap-2 rounded-md border border-slate-300 px-2 py-1">
+                <input
+                  type="checkbox"
+                  checked={(query.status ?? []).includes(status)}
+                  onChange={() => toggleStatus(status)}
+                />
+                <span>{status}</span>
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Role</span>
+          <select
+            value={query.role ?? ''}
+            onChange={(e) => setPartialQuery({ role: (e.target.value as UserRole) || '' })}
+            className="rounded-lg border border-slate-300 px-3 py-2"
+          >
+            <option value="">All roles</option>
+            <option value="ADMIN">ADMIN</option>
+            <option value="USER">USER</option>
+          </select>
+        </label>
+
+        <label className="inline-flex items-center gap-2 text-sm font-medium text-slate-700">
+          <input
+            type="checkbox"
+            checked={query.hasActiveRefreshTokens === true}
+            onChange={(e) =>
+              setPartialQuery({
+                hasActiveRefreshTokens: e.target.checked ? true : undefined,
+              })
+            }
+          />
+          Has active refresh tokens
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Created from</span>
+          <input
+            type="date"
+            value={query.createdFrom ?? ''}
+            onChange={(e) => setPartialQuery({ createdFrom: e.target.value || undefined })}
+            className="rounded-lg border border-slate-300 px-3 py-2"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Created to</span>
+          <input
+            type="date"
+            value={query.createdTo ?? ''}
+            onChange={(e) => setPartialQuery({ createdTo: e.target.value || undefined })}
+            className="rounded-lg border border-slate-300 px-3 py-2"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Sort by</span>
+          <select
+            value={query.sortBy}
+            onChange={(e) => setQuery((prev) => ({ ...prev, sortBy: e.target.value as AdminUsersQuery['sortBy'] }))}
+            className="rounded-lg border border-slate-300 px-3 py-2"
+          >
+            {SORT_FIELDS.map((field) => (
+              <option key={field} value={field}>
+                {field}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Direction</span>
+          <button
+            type="button"
+            onClick={() =>
+              setQuery((prev) => ({
+                ...prev,
+                sortDir: prev.sortDir === 'asc' ? 'desc' : 'asc',
+              }))
+            }
+            className="rounded-lg border border-slate-300 px-3 py-2 text-left"
+          >
+            {query.sortDir?.toUpperCase()}
+          </button>
+        </label>
+
+        <div className="md:col-span-2 xl:col-span-4">
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium"
+          >
+            Clear filters
+          </button>
+        </div>
+      </form>
+
+      {error ? <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-red-700">{error}</div> : null}
+
+      {loading ? <p className="text-slate-600">Loading users...</p> : null}
+
+      {!loading && items.length === 0 ? (
+        <div className="rounded-lg border border-slate-200 bg-white p-6 text-center text-slate-600">No users found for the selected filters.</div>
+      ) : null}
+
+      {!loading && items.length > 0 ? (
+        <>
+          <div className="hidden overflow-x-auto rounded-xl border border-slate-200 bg-white md:block">
+            <table className="min-w-full text-left text-sm">
+              <thead className="bg-slate-50 text-slate-600">
+                <tr>
+                  <th className="px-4 py-3">Name</th>
+                  <th className="px-4 py-3">Email</th>
+                  <th className="px-4 py-3">Role</th>
+                  <th className="px-4 py-3">Status</th>
+                  <th className="px-4 py-3">Plan / Price</th>
+                  <th className="px-4 py-3">Notes</th>
+                  <th className="px-4 py-3">Tokens</th>
+                  <th className="px-4 py-3">Last login</th>
+                  <th className="px-4 py-3">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {items.map((user) => (
+                  <tr key={user.id} className="border-t border-slate-100">
+                    <td className="px-4 py-3">{`${user.firstName} ${user.lastName}`}</td>
+                    <td className="px-4 py-3">{user.email}</td>
+                    <td className="px-4 py-3">{user.role}</td>
+                    <td className="px-4 py-3">{user.status}</td>
+                    <td className="px-4 py-3">{`${user.plan || '—'} / ${formatPrice(user.priceCents, user.currency)}`}</td>
+                    <td className="px-4 py-3">{user.notesCount}</td>
+                    <td className="px-4 py-3" title={`Last issued: ${formatDate(user.refreshTokens.lastIssuedAt)}`}>
+                      {user.refreshTokens.activeCount}
+                    </td>
+                    <td className="px-4 py-3">{formatDate(user.lastLoginAt)}</td>
+                    <td className="px-4 py-3">{formatDate(user.createdAt)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="space-y-3 md:hidden">
+            {items.map((user) => (
+              <article key={user.id} className="space-y-2 rounded-xl border border-slate-200 bg-white p-4 text-sm">
+                <h2 className="font-semibold text-slate-900">{`${user.firstName} ${user.lastName}`}</h2>
+                <p>{user.email}</p>
+                <p>Role: {user.role}</p>
+                <p>Status: {user.status}</p>
+                <p>Plan: {user.plan || '—'} ({formatPrice(user.priceCents, user.currency)})</p>
+                <p>Notes: {user.notesCount}</p>
+                <p>Active refresh tokens: {user.refreshTokens.activeCount}</p>
+                <p>Last login: {formatDate(user.lastLoginAt)}</p>
+                <p>Created: {formatDate(user.createdAt)}</p>
+              </article>
+            ))}
+          </div>
+        </>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-slate-200 bg-white p-4 text-sm">
+        <p>
+          Page {query.page} of {totalPages} • {total} users
+        </p>
+        <div className="flex items-center gap-2">
+          <label>
+            <span className="mr-2">Page size</span>
+            <select
+              value={query.pageSize}
+              onChange={(e) => setQuery((prev) => ({ ...prev, pageSize: Number(e.target.value), page: 1 }))}
+              className="rounded-lg border border-slate-300 px-2 py-1"
+            >
+              {[10, 20, 50, 100].map((size) => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => setQuery((prev) => ({ ...prev, page: Math.max(1, (prev.page || 1) - 1) }))}
+            disabled={(query.page || 1) <= 1}
+            className="rounded-lg border border-slate-300 px-3 py-1 disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <button
+            type="button"
+            onClick={() => setQuery((prev) => ({ ...prev, page: Math.min(totalPages, (prev.page || 1) + 1) }))}
+            disabled={(query.page || 1) >= totalPages}
+            className="rounded-lg border border-slate-300 px-3 py-1 disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -11,6 +11,7 @@ import { ForgotPasswordPage } from '../pages/ForgotPasswordPage';
 import { ResetPasswordPage } from '../pages/ResetPasswordPage';
 import { TermsPage } from '../pages/TermsPage';
 import { TermsConsentPage } from '../pages/TermsConsentPage';
+import { AdminUsersPage } from '../pages/AdminUsersPage';
 
 function PlaceholderPage({ title }: { title: string }) {
   return (
@@ -91,6 +92,17 @@ function RoutedApp() {
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
           <PlaceholderPage title="Settings" />
+        </AppLayout>
+      </ProtectedRoute>
+    );
+  }
+
+
+  if (path === '/admin/users') {
+    return (
+      <ProtectedRoute redirectTo="/login" requiredRole="ADMIN">
+        <AppLayout>
+          <AdminUsersPage />
         </AppLayout>
       </ProtectedRoute>
     );

--- a/BlaBlaNote/apps/front/src/router/ProtectedRoute.tsx
+++ b/BlaBlaNote/apps/front/src/router/ProtectedRoute.tsx
@@ -5,9 +5,14 @@ import { useNavigate, usePathname } from './router';
 
 interface ProtectedRouteProps extends PropsWithChildren {
   redirectTo: string;
+  requiredRole?: 'ADMIN' | 'USER';
 }
 
-export function ProtectedRoute({ children, redirectTo }: ProtectedRouteProps) {
+export function ProtectedRoute({
+  children,
+  redirectTo,
+  requiredRole,
+}: ProtectedRouteProps) {
   const { isAuthenticated, isLoading, user } = useAuth();
   const navigate = useNavigate();
   const pathname = usePathname();
@@ -25,11 +30,29 @@ export function ProtectedRoute({ children, redirectTo }: ProtectedRouteProps) {
       pathname !== '/terms-consent'
     ) {
       navigate('/terms-consent', { replace: true });
+      return;
     }
-  }, [isAuthenticated, isLoading, navigate, pathname, redirectTo, user?.termsAcceptedAt]);
+
+    if (!isLoading && isAuthenticated && requiredRole && user?.role !== requiredRole) {
+      navigate('/home', { replace: true });
+    }
+  }, [
+    isAuthenticated,
+    isLoading,
+    navigate,
+    pathname,
+    redirectTo,
+    requiredRole,
+    user?.role,
+    user?.termsAcceptedAt,
+  ]);
 
   if (isLoading || !isAuthenticated) {
     return <Loader label="Checking session..." />;
+  }
+
+  if (requiredRole && user?.role !== requiredRole) {
+    return <Loader label="Redirecting..." />;
   }
 
   return <>{children}</>;

--- a/BlaBlaNote/apps/front/src/types/admin-users.types.ts
+++ b/BlaBlaNote/apps/front/src/types/admin-users.types.ts
@@ -1,0 +1,46 @@
+export type UserStatus = 'ACTIVE' | 'SUSPENDED' | 'PENDING' | 'DELETED';
+export type UserRole = 'ADMIN' | 'USER';
+
+export interface AdminUserItem {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  role: UserRole;
+  status: UserStatus;
+  createdAt: string;
+  updatedAt: string;
+  lastLoginAt?: string | null;
+  notesCount: number;
+  plan?: string | null;
+  priceCents?: number | null;
+  currency?: string | null;
+  billingStatus?: string | null;
+  refreshTokens: {
+    activeCount: number;
+    lastIssuedAt?: string | null;
+    maxExpiresAt?: string | null;
+  };
+  termsAcceptedAt?: string | null;
+  termsVersion?: string | null;
+}
+
+export interface AdminUsersResponse {
+  items: AdminUserItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+}
+
+export interface AdminUsersQuery {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  status?: UserStatus[];
+  role?: UserRole | '';
+  hasActiveRefreshTokens?: boolean;
+  createdFrom?: string;
+  createdTo?: string;
+  sortBy?: 'createdAt' | 'lastLoginAt' | 'email' | 'price' | 'notesCount';
+  sortDir?: 'asc' | 'desc';
+}


### PR DESCRIPTION
### Motivation
- Provide an ADMIN-only management UI and API to inspect users with status, billing, notes count and safe refresh-token metadata for operations and auditing.  
- Avoid exposing sensitive auth artifacts by returning only aggregate/token-date metadata and enforcing role-based access.  
- Support scalable admin workflows with server-side pagination, filtering and sorting to prevent heavy queries.  
- Surface user observability (last login, plan, billing status) to help administrators manage accounts.  

### Description
- Backend: added a new Admin module with `GET /admin/users` protected by `JwtAuthGuard`, `RolesGuard` and `@Roles('ADMIN')`, a validated query DTO `GetAdminUsersQueryDto` for pagination/filters/sorting, and an `AdminUsersService` implementing Prisma-backed server-side filtering/sorting/pagination with safe response shaping (notes count via `_count` and refresh-token metadata as `activeCount`, `lastIssuedAt`, `maxExpiresAt`).  
- Database: extended the Prisma `User` model with `status` (new `UserStatus` enum), `lastLoginAt`, suspension/deletion timestamps and billing fields, and added SQL migration `apps/api/prisma/migrations/20260227000000_admin_users_status/migration.sql`.  
- Auth: updated login flow to persist `lastLoginAt` to improve admin observability.  
- Frontend: added `AdminUsersPage` at `/admin/users`, typed API client `adminUsersApi`, request/response models `apps/front/src/types/admin-users.types.ts`, filters/sorting UI, responsive table/cards, pagination and accessible controls, and protected the route by extending `ProtectedRoute` with a `requiredRole` prop to redirect non-admin users.  
- Security: responses deliberately omit `password`, password hashes, raw refresh tokens and token hashes; only safe token metadata (counts/dates) is returned; query DTO enforces validation and `pageSize` cap (max 100).  

### Testing
- Ran Prisma client generation with `yarn prisma generate` which completed successfully.  
- Built the backend with `NX_NO_CLOUD=true yarn nx run api:build` and the build completed successfully after regenerating the Prisma client.  
- Built the frontend with `NX_NO_CLOUD=true yarn nx run front:build` which completed successfully.  
- Served the frontend and captured a UI screenshot for the `/admin/users` route to validate the route rendering and layout (screenshot artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0aae51ae483209ea87511e0ae4a59)