### PR TITLE
feat: add projects feature and note assignment flow

### DIFF
--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -11,6 +11,8 @@ model Note {
   id          String   @id @default(uuid())
   userId      String
   user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  projectId   String?
+  project     Project? @relation(fields: [projectId], references: [id], onDelete: SetNull)
   text        String
   summary     String?
   translation String?
@@ -39,8 +41,21 @@ model User {
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   notes         Note[]
+  projects      Project[]
   refreshTokens RefreshToken[]
   passwordResetTokens PasswordResetToken[]
+}
+
+model Project {
+  id        String   @id @default(uuid())
+  name      String
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  notes     Note[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model RefreshToken {

--- a/BlaBlaNote/apps/api/src/app/app.module.ts
+++ b/BlaBlaNote/apps/api/src/app/app.module.ts
@@ -8,6 +8,7 @@ import { NoteModule } from './note/note.module';
 import { WhisperModule } from './whisper/whisper.module';
 import { DiscordModule } from './discord/discord.module';
 import { AdminModule } from './admin/admin.module';
+import { ProjectModule } from './project/project.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { AdminModule } from './admin/admin.module';
     WhisperModule,
     DiscordModule,
     AdminModule,
+    ProjectModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BlaBlaNote/apps/api/src/app/note/dto/update-note-project.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/update-note-project.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
+
+export class UpdateNoteProjectDto {
+  @ApiProperty({ nullable: true, type: String })
+  @IsOptional()
+  @IsString()
+  @IsUUID()
+  projectId: string | null;
+}

--- a/BlaBlaNote/apps/api/src/app/note/note.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/note/note.controller.ts
@@ -6,10 +6,12 @@ import {
   UseGuards,
   Req,
   Get,
+  Patch,
 } from '@nestjs/common';
 import { NoteService } from './note.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CreateNoteDto } from './dto/create-note.dto';
+import { UpdateNoteProjectDto } from './dto/update-note-project.dto';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -48,6 +50,18 @@ export class NoteController {
   async createNote(@Body() dto: CreateNoteDto, @Req() req: Request) {
     const user = req.user as AuthUser;
     return this.noteService.createNote(dto, user.id);
+  }
+
+  @Patch(':id/project')
+  @ApiOperation({ summary: 'Attach note to a project or remove it' })
+  @ApiResponse({ status: 200, description: 'Note project updated successfully' })
+  async updateNoteProject(
+    @Param('id') id: string,
+    @Body() dto: UpdateNoteProjectDto,
+    @Req() req: Request
+  ) {
+    const user = req.user as AuthUser;
+    return this.noteService.updateNoteProject(id, user.id, dto.projectId ?? null);
   }
 
   @Post(':id/share')

--- a/BlaBlaNote/apps/api/src/app/note/note.module.ts
+++ b/BlaBlaNote/apps/api/src/app/note/note.module.ts
@@ -4,9 +4,10 @@ import { NoteController } from './note.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuthModule } from '../auth/auth.module';
 import { DiscordModule } from '../discord/discord.module';
+import { ProjectModule } from '../project/project.module';
 
 @Module({
-  imports: [PrismaModule, AuthModule, DiscordModule],
+  imports: [PrismaModule, AuthModule, DiscordModule, ProjectModule],
   controllers: [NoteController],
   providers: [NoteService],
 })

--- a/BlaBlaNote/apps/api/src/app/project/dto/create-project.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/project/dto/create-project.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateProjectDto {
+  @ApiProperty({ description: 'Project name', maxLength: 120 })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  name: string;
+}

--- a/BlaBlaNote/apps/api/src/app/project/dto/get-projects-query.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/project/dto/get-projects-query.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+
+enum ProjectsScope {
+  mine = 'mine',
+  all = 'all',
+}
+
+export class GetProjectsQueryDto {
+  @ApiPropertyOptional({ enum: ProjectsScope, default: ProjectsScope.mine })
+  @IsOptional()
+  @IsEnum(ProjectsScope)
+  scope?: ProjectsScope = ProjectsScope.mine;
+}
+
+export { ProjectsScope };

--- a/BlaBlaNote/apps/api/src/app/project/dto/update-project.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/project/dto/update-project.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateProjectDto } from './create-project.dto';
+
+export class UpdateProjectDto extends PartialType(CreateProjectDto) {}

--- a/BlaBlaNote/apps/api/src/app/project/project.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/project/project.controller.ts
@@ -1,0 +1,58 @@
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+import { GetProjectsQueryDto } from './dto/get-projects-query.dto';
+import { ProjectService } from './project.service';
+
+type AuthUser = {
+  id: string;
+  email: string;
+  role: 'ADMIN' | 'USER';
+};
+
+@ApiTags('Projects')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@Controller('projects')
+export class ProjectController {
+  constructor(private readonly projectService: ProjectService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get projects for the current user' })
+  @ApiResponse({ status: 200, description: 'Projects list' })
+  getProjects(@Req() req: Request, @Query() query: GetProjectsQueryDto) {
+    const user = req.user as AuthUser;
+    return this.projectService.getProjects(user.id, user.role === 'ADMIN', query.scope);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a project' })
+  createProject(@Req() req: Request, @Body() dto: CreateProjectDto) {
+    const user = req.user as AuthUser;
+    return this.projectService.createProject(user.id, dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Rename a project' })
+  renameProject(@Req() req: Request, @Param('id') id: string, @Body() dto: UpdateProjectDto) {
+    const user = req.user as AuthUser;
+    return this.projectService.renameProject(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a project' })
+  deleteProject(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as AuthUser;
+    return this.projectService.deleteProject(user.id, id);
+  }
+
+  @Get(':id/notes')
+  @ApiOperation({ summary: 'Get notes in a project' })
+  getProjectNotes(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as AuthUser;
+    return this.projectService.getProjectNotes(user.id, id);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/project/project.module.ts
+++ b/BlaBlaNote/apps/api/src/app/project/project.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ProjectController } from './project.controller';
+import { ProjectService } from './project.service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [ProjectController],
+  providers: [ProjectService],
+  exports: [ProjectService],
+})
+export class ProjectModule {}

--- a/BlaBlaNote/apps/api/src/app/project/project.service.ts
+++ b/BlaBlaNote/apps/api/src/app/project/project.service.ts
@@ -1,0 +1,119 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateProjectDto } from './dto/create-project.dto';
+import { UpdateProjectDto } from './dto/update-project.dto';
+
+@Injectable()
+export class ProjectService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getProjects(userId: string, isAdmin: boolean, scope: 'mine' | 'all' = 'mine') {
+    const where = isAdmin && scope === 'all' ? {} : { userId };
+
+    const projects = await this.prisma.project.findMany({
+      where,
+      include: {
+        _count: {
+          select: { notes: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
+
+    return projects.map((project) => ({
+      id: project.id,
+      name: project.name,
+      notesCount: project._count.notes,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    }));
+  }
+
+  async createProject(userId: string, dto: CreateProjectDto) {
+    const project = await this.prisma.project.create({
+      data: {
+        userId,
+        name: dto.name,
+      },
+      include: {
+        _count: {
+          select: { notes: true },
+        },
+      },
+    });
+
+    return {
+      id: project.id,
+      name: project.name,
+      notesCount: project._count.notes,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    };
+  }
+
+  async renameProject(userId: string, id: string, dto: UpdateProjectDto) {
+    await this.ensureProjectOwnership(id, userId);
+
+    const project = await this.prisma.project.update({
+      where: { id },
+      data: { name: dto.name },
+      include: {
+        _count: {
+          select: { notes: true },
+        },
+      },
+    });
+
+    return {
+      id: project.id,
+      name: project.name,
+      notesCount: project._count.notes,
+      createdAt: project.createdAt,
+      updatedAt: project.updatedAt,
+    };
+  }
+
+  async deleteProject(userId: string, id: string) {
+    await this.ensureProjectOwnership(id, userId);
+
+    await this.prisma.project.delete({ where: { id } });
+
+    return { success: true };
+  }
+
+  async getProjectNotes(userId: string, id: string) {
+    await this.ensureProjectOwnership(id, userId);
+
+    const project = await this.prisma.project.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        notes: {
+          where: { userId },
+          orderBy: { createdAt: 'desc' },
+        },
+      },
+    });
+
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    return project;
+  }
+
+  async ensureProjectOwnership(projectId: string, userId: string) {
+    const project = await this.prisma.project.findUnique({ where: { id: projectId } });
+
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    if (project.userId !== userId) {
+      throw new ForbiddenException('You cannot access this project');
+    }
+
+    return project;
+  }
+}

--- a/BlaBlaNote/apps/front/src/api/notes.api.ts
+++ b/BlaBlaNote/apps/front/src/api/notes.api.ts
@@ -8,6 +8,9 @@ export const notesApi = {
   getById(id: string) {
     return http.get<Note>(`/notes/${id}`).then((res) => res.data);
   },
+  create(payload: { text: string }) {
+    return http.post<Note>('/notes', payload).then((res) => res.data);
+  },
   createAudioNote(file: File) {
     const formData = new FormData();
     formData.append('file', file);
@@ -22,6 +25,11 @@ export const notesApi = {
   },
   delete(id: string) {
     return http.delete(`/notes/${id}`).then((res) => res.data);
+  },
+  updateProject(id: string, projectId: string | null) {
+    return http
+      .patch<Note>(`/notes/${id}/project`, { projectId })
+      .then((res) => res.data);
   },
   share(id: string, payload: ShareNotePayload) {
     return http.post(`/notes/${id}/share`, payload).then((res) => res.data);

--- a/BlaBlaNote/apps/front/src/api/projects.api.ts
+++ b/BlaBlaNote/apps/front/src/api/projects.api.ts
@@ -1,5 +1,10 @@
 import { http } from './http';
-import { CreateProjectPayload, Project } from '../types/projects.types';
+import {
+  CreateProjectPayload,
+  Project,
+  ProjectDetail,
+  UpdateProjectPayload,
+} from '../types/projects.types';
 
 export const projectsApi = {
   getAll() {
@@ -7,5 +12,14 @@ export const projectsApi = {
   },
   create(payload: CreateProjectPayload) {
     return http.post<Project>('/projects', payload).then((res) => res.data);
+  },
+  update(id: string, payload: UpdateProjectPayload) {
+    return http.patch<Project>(`/projects/${id}`, payload).then((res) => res.data);
+  },
+  delete(id: string) {
+    return http.delete<{ success: boolean }>(`/projects/${id}`).then((res) => res.data);
+  },
+  getNotes(id: string) {
+    return http.get<ProjectDetail>(`/projects/${id}/notes`).then((res) => res.data);
   },
 };

--- a/BlaBlaNote/apps/front/src/components/layout/AppHeader.tsx
+++ b/BlaBlaNote/apps/front/src/components/layout/AppHeader.tsx
@@ -28,6 +28,7 @@ export function AppHeader() {
     { label: t('nav.home'), to: '/home' },
     { label: t('nav.notes'), to: '/notes' },
     { label: t('nav.createNote'), to: '/notes/new' },
+    { label: 'Projects', to: '/projects' },
   ] as const;
 
   const initials = [user?.firstName, user?.lastName]

--- a/BlaBlaNote/apps/front/src/pages/ProjectDetailPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,130 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { notesApi } from '../api/notes.api';
+import { projectsApi } from '../api/projects.api';
+import { Loader } from '../components/ui/Loader';
+import { useProjects } from '../hooks/useProjects';
+import { ApiError } from '../types/api.types';
+import { Note } from '../types/notes.types';
+
+interface ProjectDetailPageProps {
+  projectId: string;
+}
+
+export function ProjectDetailPage({ projectId }: ProjectDetailPageProps) {
+  const [name, setName] = useState('');
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [newNoteText, setNewNoteText] = useState('');
+  const { projects } = useProjects();
+
+  const targetProjects = useMemo(() => projects.filter((project) => project.id !== projectId), [projects, projectId]);
+
+  async function loadProject() {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await projectsApi.getNotes(projectId);
+      setName(data.name);
+      setNotes(data.notes);
+    } catch (err) {
+      setError((err as ApiError).message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadProject();
+  }, [projectId]);
+
+  async function onCreateNote(event: FormEvent) {
+    event.preventDefault();
+
+    try {
+      const note = await notesApi.create({ text: newNoteText });
+      await notesApi.updateProject(note.id, projectId);
+      setNewNoteText('');
+      await loadProject();
+    } catch (err) {
+      setError((err as ApiError).message);
+    }
+  }
+
+  async function onMove(noteId: string, targetProjectId: string | null) {
+    try {
+      await notesApi.updateProject(noteId, targetProjectId);
+      await loadProject();
+    } catch (err) {
+      setError((err as ApiError).message);
+    }
+  }
+
+  if (isLoading) {
+    return <Loader label="Loading project..." />;
+  }
+
+  if (error) {
+    return <p className="error-text">{error}</p>;
+  }
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-bold text-slate-900">{name}</h1>
+      </header>
+
+      <form className="space-y-2 rounded-xl border border-slate-200 bg-white p-4" onSubmit={onCreateNote}>
+        <h2 className="font-semibold">Add note to project</h2>
+        <textarea
+          className="min-h-24 w-full rounded-lg border border-slate-300 px-3 py-2"
+          value={newNoteText}
+          onChange={(event) => setNewNoteText(event.target.value)}
+          placeholder="Write a note..."
+          required
+        />
+        <button className="rounded-md bg-slate-900 px-4 py-2 text-sm text-white">Add note</button>
+      </form>
+
+      {notes.length === 0 ? <p className="text-slate-500">No notes in this project.</p> : null}
+
+      <ul className="space-y-3">
+        {notes.map((note) => (
+          <li key={note.id} className="space-y-2 rounded-xl border border-slate-200 bg-white p-4">
+            <p className="font-medium">{new Date(note.createdAt).toLocaleString()}</p>
+            <p className="text-sm text-slate-700">{note.summary ?? note.text.slice(0, 180)}</p>
+            <div className="flex flex-wrap gap-2">
+              <select
+                className="rounded-md border border-slate-300 px-2 py-1.5 text-sm"
+                defaultValue=""
+                onChange={(event) => {
+                  const value = event.target.value;
+                  if (!value) {
+                    return;
+                  }
+                  void onMove(note.id, value);
+                }}
+              >
+                <option value="">Move to project...</option>
+                {targetProjects.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.name}
+                  </option>
+                ))}
+              </select>
+              <button
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+                onClick={() => {
+                  void onMove(note.id, null);
+                }}
+              >
+                Remove from project
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/ProjectsPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/ProjectsPage.tsx
@@ -1,0 +1,135 @@
+import { FormEvent, useState } from 'react';
+import { projectsApi } from '../api/projects.api';
+import { Loader } from '../components/ui/Loader';
+import { useProjects } from '../hooks/useProjects';
+import { useNavigate } from '../router/router';
+import { ApiError } from '../types/api.types';
+
+export function ProjectsPage() {
+  const { projects, isLoading, error, refetch } = useProjects();
+  const navigate = useNavigate();
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  async function onCreate(event: FormEvent) {
+    event.preventDefault();
+    setActionError(null);
+
+    try {
+      await projectsApi.create({ name: newName });
+      setNewName('');
+      await refetch();
+    } catch (err) {
+      setActionError((err as ApiError).message);
+    }
+  }
+
+  async function onDelete(projectId: string) {
+    if (!window.confirm('Delete this project? Notes will stay but be unassigned.')) {
+      return;
+    }
+
+    setActionError(null);
+
+    try {
+      await projectsApi.delete(projectId);
+      await refetch();
+    } catch (err) {
+      setActionError((err as ApiError).message);
+    }
+  }
+
+  async function onRename(event: FormEvent) {
+    event.preventDefault();
+
+    if (!editingId) {
+      return;
+    }
+
+    setActionError(null);
+
+    try {
+      await projectsApi.update(editingId, { name: editingName });
+      setEditingId(null);
+      setEditingName('');
+      await refetch();
+    } catch (err) {
+      setActionError((err as ApiError).message);
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h1 className="text-2xl font-bold text-slate-900">Projects</h1>
+      </header>
+
+      <form className="flex gap-2" onSubmit={onCreate}>
+        <input
+          className="w-full rounded-lg border border-slate-300 px-3 py-2"
+          value={newName}
+          onChange={(event) => setNewName(event.target.value)}
+          placeholder="Create Project"
+          required
+        />
+        <button className="rounded-lg bg-slate-900 px-4 py-2 text-white">Create</button>
+      </form>
+
+      {isLoading ? <Loader label="Loading projects..." /> : null}
+      {error ? <p className="error-text">{error}</p> : null}
+      {actionError ? <p className="error-text">{actionError}</p> : null}
+
+      {!isLoading && projects.length === 0 ? (
+        <p className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center text-slate-500">No projects yet.</p>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {projects.map((project) => (
+          <article key={project.id} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            {editingId === project.id ? (
+              <form className="space-y-2" onSubmit={onRename}>
+                <input
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2"
+                  value={editingName}
+                  onChange={(event) => setEditingName(event.target.value)}
+                  required
+                />
+                <div className="flex gap-2">
+                  <button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white">Save</button>
+                  <button type="button" className="rounded-md border border-slate-300 px-3 py-1.5 text-sm" onClick={() => setEditingId(null)}>
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <>
+                <h3 className="text-lg font-semibold">{project.name}</h3>
+                <p className="text-sm text-slate-600">{project.notesCount} notes</p>
+                <p className="text-xs text-slate-500">Created {new Date(project.createdAt).toLocaleDateString()}</p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white" onClick={() => navigate(`/projects/${project.id}`)}>
+                    Open
+                  </button>
+                  <button
+                    className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+                    onClick={() => {
+                      setEditingId(project.id);
+                      setEditingName(project.name);
+                    }}
+                  >
+                    Edit
+                  </button>
+                  <button className="rounded-md border border-red-300 px-3 py-1.5 text-sm text-red-700" onClick={() => onDelete(project.id)}>
+                    Delete
+                  </button>
+                </div>
+              </>
+            )}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -7,6 +7,8 @@ import { LoginPage } from '../pages/LoginPage';
 import { NoteDetailPage } from '../pages/NoteDetailPage';
 import { NotesListPage } from '../pages/NotesListPage';
 import { RegisterPage } from '../pages/RegisterPage';
+import { ProjectsPage } from '../pages/ProjectsPage';
+import { ProjectDetailPage } from '../pages/ProjectDetailPage';
 import { ProtectedRoute } from './ProtectedRoute';
 import { matchPath, RouterProvider, usePathname } from './router';
 import { ForgotPasswordPage } from '../pages/ForgotPasswordPage';
@@ -111,6 +113,17 @@ function RoutedApp() {
     );
   }
 
+
+  if (path === '/projects') {
+    return (
+      <ProtectedRoute redirectTo="/login">
+        <AppLayout>
+          <ProjectsPage />
+        </AppLayout>
+      </ProtectedRoute>
+    );
+  }
+
   if (path === '/profile') {
     return (
       <ProtectedRoute redirectTo="/login">
@@ -135,6 +148,18 @@ function RoutedApp() {
     return (
       <ProtectedRoute redirectTo="/login" requiredRole={ROLES.ADMIN}>
         <AdminLayout>{renderAdminPage(path)}</AdminLayout>
+      </ProtectedRoute>
+    );
+  }
+
+
+  const projectMatch = matchPath('/projects/:id', path);
+  if (projectMatch) {
+    return (
+      <ProtectedRoute redirectTo="/login">
+        <AppLayout>
+          <ProjectDetailPage projectId={projectMatch.id} />
+        </AppLayout>
       </ProtectedRoute>
     );
   }

--- a/BlaBlaNote/apps/front/src/types/notes.types.ts
+++ b/BlaBlaNote/apps/front/src/types/notes.types.ts
@@ -7,6 +7,7 @@ export interface Note {
   summary: string | null;
   translation: string | null;
   audioUrl: string | null;
+  projectId: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/BlaBlaNote/apps/front/src/types/projects.types.ts
+++ b/BlaBlaNote/apps/front/src/types/projects.types.ts
@@ -1,9 +1,23 @@
+import { Note } from './notes.types';
+
 export interface Project {
   id: string;
   name: string;
+  notesCount: number;
   createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectDetail {
+  id: string;
+  name: string;
+  notes: Note[];
 }
 
 export interface CreateProjectPayload {
+  name: string;
+}
+
+export interface UpdateProjectPayload {
   name: string;
 }


### PR DESCRIPTION
### Motivation
- Introduce Projects so users can organize Notes into multiple workspaces while keeping existing notes behavior unchanged.
- Allow attaching/detaching Notes to Projects and provide REST endpoints and UI pages for full CRUD and note-management flows.
- Enforce strict ownership and optional admin "all" scope to prevent cross-user access.

### Description
- Updated Prisma schema to add `Project` model, `User.projects` and nullable `Note.projectId` relation with `onDelete: SetNull` to preserve unassigned notes behavior and safe deletion.
- Implemented backend `ProjectModule` with `ProjectService` and `ProjectController` exposing `GET /projects`, `POST /projects`, `PATCH /projects/:id`, `DELETE /projects/:id`, and `GET /projects/:id/notes`, plus DTOs for input validation and an optional `scope` query for admins.
- Added `PATCH /notes/:id/project` and `UpdateNoteProjectDto`, plus `NoteService.updateNoteProject` that validates note ownership and project ownership before updating `projectId` (nullable to remove assignment).
- Wire-up: registered `ProjectModule` in `AppModule`, added `ProjectModule` import to `NoteModule` to resolve ownership checks, and regenerated Prisma client usage in code.
- Frontend changes: added `ProjectsPage` and `ProjectDetailPage`, new `projectsApi` methods, extended `notesApi.updateProject`, updated types (`Project`, `ProjectDetail`, `Note.projectId`), added routes (`/projects`, `/projects/:id`), and navigation link in header; UI supports create/rename/delete, view notes, add note to project, move/remove notes, loading and empty states.
- Migration instructions added: run `yarn prisma migrate dev --schema apps/api/prisma/schema.prisma --name add-projects-to-notes` then `yarn prisma generate --schema apps/api/prisma/schema.prisma` (see Testing for environment note).

### Testing
- `yarn prisma generate --schema apps/api/prisma/schema.prisma` — succeeded (Prisma client generated).
- `yarn prisma migrate dev --schema apps/api/prisma/schema.prisma --name add-projects-to-notes` — attempted but failed in this environment due to missing `DATABASE_URL` (environment not configured), so migration must be run locally/CI with DB credentials.
- `NX_NO_CLOUD=true yarn nx run api:build` — succeeded (API TypeScript build completed after regenerating Prisma client).
- `NX_NO_CLOUD=true yarn nx run front:build` — succeeded (frontend built for production).
- UI smoke: served frontend and took a Playwright screenshot of the Projects page (artifact: `browser:/tmp/codex_browser_invocations/882413696765655b/artifacts/artifacts/projects-page.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0f68a79308320bd3dbf8e958d47ac)