### PR TITLE
feat(api): add tags system and note tag filtering

### DIFF
--- a/BlaBlaNote/apps/api/prisma/migrations/20260228000000_tags_feature/migration.sql
+++ b/BlaBlaNote/apps/api/prisma/migrations/20260228000000_tags_feature/migration.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "Tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "NoteTag" (
+    "noteId" TEXT NOT NULL,
+    "tagId" TEXT NOT NULL,
+    CONSTRAINT "NoteTag_pkey" PRIMARY KEY ("noteId", "tagId")
+);
+
+CREATE INDEX "Tag_userId_idx" ON "Tag"("userId");
+CREATE UNIQUE INDEX "Tag_userId_slug_key" ON "Tag"("userId", "slug");
+CREATE INDEX "NoteTag_noteId_idx" ON "NoteTag"("noteId");
+CREATE INDEX "NoteTag_tagId_idx" ON "NoteTag"("tagId");
+
+ALTER TABLE "Tag" ADD CONSTRAINT "Tag_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "NoteTag" ADD CONSTRAINT "NoteTag_noteId_fkey" FOREIGN KEY ("noteId") REFERENCES "Note"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "NoteTag" ADD CONSTRAINT "NoteTag_tagId_fkey" FOREIGN KEY ("tagId") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Note {
   audioUrl    String?
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
+  noteTags    NoteTag[]
 
   @@index([projectId])
 }
@@ -43,10 +44,36 @@ model User {
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
   notes         Note[]
+  tags          Tag[]
   projects      Project[]
   blogPosts     BlogPost[]
   refreshTokens RefreshToken[]
   passwordResetTokens PasswordResetToken[]
+}
+
+model Tag {
+  id        String    @id @default(cuid())
+  name      String
+  slug      String
+  userId    String
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  noteTags  NoteTag[]
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@unique([userId, slug])
+  @@index([userId])
+}
+
+model NoteTag {
+  noteId String
+  tagId  String
+  note   Note   @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  tag    Tag    @relation(fields: [tagId], references: [id], onDelete: Cascade)
+
+  @@id([noteId, tagId])
+  @@index([noteId])
+  @@index([tagId])
 }
 
 model BlogCategory {

--- a/BlaBlaNote/apps/api/src/app/app.module.ts
+++ b/BlaBlaNote/apps/api/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { DiscordModule } from './discord/discord.module';
 import { AdminModule } from './admin/admin.module';
 import { ProjectModule } from './project/project.module';
 import { BlogModule } from './blog/blog.module';
+import { TagModule } from './tag/tag.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { BlogModule } from './blog/blog.module';
     AdminModule,
     ProjectModule,
     BlogModule,
+    TagModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BlaBlaNote/apps/api/src/app/note/dto/get-notes-query.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/get-notes-query.dto.ts
@@ -1,0 +1,35 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+function toArray(value: unknown) {
+  if (!value) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((item) => String(item).split(','))
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return String(value)
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+export class GetNotesQueryDto {
+  @ApiPropertyOptional({
+    type: [String],
+    description:
+      'Filter notes by tags, supports repeated params or comma-separated values',
+    example: ['tag-id-1', 'tag-id-2'],
+  })
+  @IsOptional()
+  @Transform(({ value }) => toArray(value))
+  @IsArray()
+  @IsString({ each: true })
+  tagIds?: string[];
+}

--- a/BlaBlaNote/apps/api/src/app/note/dto/replace-note-tags.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/replace-note-tags.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsString } from 'class-validator';
+
+export class ReplaceNoteTagsDto {
+  @ApiProperty({
+    type: [String],
+    description: 'List of tag ids to attach to the note',
+  })
+  @IsArray()
+  @IsString({ each: true })
+  tagIds: string[];
+}

--- a/BlaBlaNote/apps/api/src/app/tag/dto/create-tag.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/tag/dto/create-tag.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class CreateTagDto {
+  @ApiProperty({ description: 'Tag name', example: 'Important' })
+  @IsString()
+  @MinLength(1)
+  name: string;
+}

--- a/BlaBlaNote/apps/api/src/app/tag/dto/update-tag.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/tag/dto/update-tag.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateTagDto } from './create-tag.dto';
+
+export class UpdateTagDto extends PartialType(CreateTagDto) {}

--- a/BlaBlaNote/apps/api/src/app/tag/tag.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/tag/tag.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TagService } from './tag.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+
+type AuthUser = {
+  id: string;
+  email: string;
+  role: 'ADMIN' | 'USER';
+};
+
+@ApiTags('Tags')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@Controller('tags')
+export class TagController {
+  constructor(private readonly tagService: TagService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List current user tags' })
+  @ApiResponse({ status: 200, description: 'Tags list' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  getTags(@Req() req: Request) {
+    const user = req.user as AuthUser;
+    return this.tagService.getTags(user.id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create a tag' })
+  @ApiResponse({ status: 201, description: 'Tag created successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  createTag(@Req() req: Request, @Body() dto: CreateTagDto) {
+    const user = req.user as AuthUser;
+    return this.tagService.createTag(user.id, dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Rename a tag' })
+  @ApiResponse({ status: 200, description: 'Tag renamed successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Tag not found' })
+  updateTag(
+    @Req() req: Request,
+    @Param('id') id: string,
+    @Body() dto: UpdateTagDto
+  ) {
+    const user = req.user as AuthUser;
+    return this.tagService.updateTag(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete a tag' })
+  @ApiResponse({ status: 200, description: 'Tag deleted successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Tag not found' })
+  deleteTag(@Req() req: Request, @Param('id') id: string) {
+    const user = req.user as AuthUser;
+    return this.tagService.deleteTag(user.id, id);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/tag/tag.module.ts
+++ b/BlaBlaNote/apps/api/src/app/tag/tag.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TagController } from './tag.controller';
+import { TagService } from './tag.service';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [PrismaModule, AuthModule],
+  controllers: [TagController],
+  providers: [TagService],
+  exports: [TagService],
+})
+export class TagModule {}

--- a/BlaBlaNote/apps/api/src/app/tag/tag.service.ts
+++ b/BlaBlaNote/apps/api/src/app/tag/tag.service.ts
@@ -1,0 +1,88 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateTagDto } from './dto/create-tag.dto';
+import { UpdateTagDto } from './dto/update-tag.dto';
+import { buildUniqueSlug } from '../blog/utils/slug';
+
+@Injectable()
+export class TagService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  getTags(userId: string) {
+    return this.prisma.tag.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async createTag(userId: string, dto: CreateTagDto) {
+    const slug = await this.getUniqueSlug(userId, dto.name);
+    return this.prisma.tag.create({
+      data: {
+        userId,
+        name: dto.name,
+        slug,
+      },
+    });
+  }
+
+  async updateTag(userId: string, id: string, dto: UpdateTagDto) {
+    const existing = await this.ensureTagOwnership(id, userId);
+    const slug = dto.name
+      ? await this.getUniqueSlug(userId, dto.name, existing.slug)
+      : existing.slug;
+
+    return this.prisma.tag.update({
+      where: { id },
+      data: {
+        name: dto.name,
+        slug,
+      },
+    });
+  }
+
+  async deleteTag(userId: string, id: string) {
+    await this.ensureTagOwnership(id, userId);
+    await this.prisma.tag.delete({ where: { id } });
+    return { success: true };
+  }
+
+  async ensureTagOwnership(tagId: string, userId: string) {
+    const tag = await this.prisma.tag.findUnique({ where: { id: tagId } });
+
+    if (!tag) {
+      throw new NotFoundException('Tag not found');
+    }
+
+    if (tag.userId !== userId) {
+      throw new ForbiddenException('You cannot access this tag');
+    }
+
+    return tag;
+  }
+
+  private async getUniqueSlug(
+    userId: string,
+    name: string,
+    excludedSlug?: string
+  ) {
+    return buildUniqueSlug(
+      name,
+      async (slug) =>
+        Boolean(
+          await this.prisma.tag.findFirst({
+            where: {
+              userId,
+              slug,
+            },
+            select: { id: true },
+          })
+        ),
+      excludedSlug
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a per-user tagging system so users can create tags, attach them to notes and filter notes by multiple tags with AND semantics.

### Description
- Update Prisma schema to add `Tag` and `NoteTag` models, relations `User.tags` and `Note.noteTags`, and a per-user unique slug via `@@unique([userId, slug])`.
- Add SQL migration `apps/api/prisma/migrations/20260228000000_tags_feature/migration.sql` creating `Tag` and `NoteTag` tables, indexes and foreign keys with cascade behavior.
- Implement `TagModule` with `TagService`, `TagController` and DTOs `CreateTagDto` / `UpdateTagDto` exposing `GET /tags`, `POST /tags`, `PATCH /tags/:id` and `DELETE /tags/:id` and auto-generating per-user unique slugs using `buildUniqueSlug`.
- Extend notes API with `GET /notes?tagIds=...` using `GetNotesQueryDto` for repeated or comma-separated `tagIds` and `PUT /notes/:id/tags` implemented in `NoteService.replaceNoteTags` that enforces note and tag ownership and uses `prisma.noteTag.deleteMany` / `prisma.noteTag.createMany`; register `TagModule` in `AppModule` and add Swagger docs for new routes and DTOs.

### Testing
- Ran `npx prisma generate --schema apps/api/prisma/schema.prisma` which failed due to Prisma engine download `403 Forbidden` in this environment.
- Ran `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate --schema apps/api/prisma/schema.prisma` which still failed because the Prisma engine binary could not be downloaded (`403 Forbidden`).
- Ran `yarn nx lint api` (and `NX_NO_CLOUD=1 yarn nx lint api`) where the lint target executed successfully but the overall command exited non-zero due to an Nx Cloud download failure in the environment.
- Ran `prettier` formatting which completed for TypeScript files while reporting parser warnings for `.prisma` and SQL migration files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1f8f1406483209245604a292b9b25)