### PR TITLE
feat(api): add pagination, search and filters to GET /notes

### DIFF
--- a/BlaBlaNote/apps/api/src/app/note/dto/get-notes-query.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/get-notes-query.dto.ts
@@ -1,6 +1,14 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Transform } from 'class-transformer';
-import { IsArray, IsOptional, IsString } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 function toArray(value: unknown) {
   if (!value) {
@@ -21,6 +29,31 @@ function toArray(value: unknown) {
 }
 
 export class GetNotesQueryDto {
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiPropertyOptional({ example: 20, default: 20 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  pageSize?: number = 20;
+
+  @ApiPropertyOptional({ example: 'meeting' })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({ example: 'project-id-1' })
+  @IsOptional()
+  @IsString()
+  projectId?: string;
+
   @ApiPropertyOptional({
     type: [String],
     description:
@@ -32,4 +65,18 @@ export class GetNotesQueryDto {
   @IsArray()
   @IsString({ each: true })
   tagIds?: string[];
+
+  @ApiPropertyOptional({
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({
+    example: '2026-01-31T23:59:59.999Z',
+  })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
 }

--- a/BlaBlaNote/apps/api/src/app/note/dto/get-notes-response.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/get-notes-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetNotesResponseDto {
+  @ApiProperty({ type: 'array', items: { type: 'object' } })
+  items: Record<string, unknown>[];
+
+  @ApiProperty({ example: 1 })
+  page: number;
+
+  @ApiProperty({ example: 20 })
+  pageSize: number;
+
+  @ApiProperty({ example: 42 })
+  total: number;
+}

--- a/BlaBlaNote/apps/api/src/app/note/note.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/note/note.controller.ts
@@ -16,6 +16,7 @@ import { CreateNoteDto } from './dto/create-note.dto';
 import { UpdateNoteProjectDto } from './dto/update-note-project.dto';
 import { ReplaceNoteTagsDto } from './dto/replace-note-tags.dto';
 import { GetNotesQueryDto } from './dto/get-notes-query.dto';
+import { GetNotesResponseDto } from './dto/get-notes-response.dto';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -41,6 +42,10 @@ export class NoteController {
 
   @Get()
   @ApiOperation({ summary: 'Get all notes for the current user' })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number, example: 20 })
+  @ApiQuery({ name: 'search', required: false, type: String })
+  @ApiQuery({ name: 'projectId', required: false, type: String })
   @ApiQuery({
     name: 'tagIds',
     required: false,
@@ -48,7 +53,9 @@ export class NoteController {
     description: 'Filter notes that contain all provided tags',
     isArray: true,
   })
-  @ApiResponse({ status: 200, description: 'List of notes' })
+  @ApiQuery({ name: 'dateFrom', required: false, type: String })
+  @ApiQuery({ name: 'dateTo', required: false, type: String })
+  @ApiResponse({ status: 200, description: 'Paginated notes list', type: GetNotesResponseDto })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   async getMyNotes(@Req() req: Request, @Query() query: GetNotesQueryDto) {
     const user = req.user as AuthUser;


### PR DESCRIPTION
### Motivation
- Provide a paginated, searchable and filterable `GET /notes` API so clients can request user-owned notes with page controls and combined filters (project, tags, date range, free-text).
- Ensure API is documented in Swagger with an explicit paginated response shape.

### Description
- Extended `GetNotesQueryDto` with `page`, `pageSize`, `search`, `projectId`, `tagIds`, `dateFrom`, and `dateTo` including transforms and validation rules. 
- Added `GetNotesResponseDto` to document the `{ items, page, pageSize, total }` response shape. 
- Updated `NoteController` Swagger annotations to declare all query parameters and the paginated response (`GetNotesResponseDto`).
- Reworked `NoteService.getNotesByUser` to build a `Prisma.NoteWhereInput` that scopes to `userId`, applies case-insensitive `search` over `text` and `summary`, optional `projectId`, date-range (`dateFrom`/`dateTo`) on `createdAt`, tag AND semantics (note must contain all `tagIds`), orders by `createdAt DESC`, and returns paginated results with total count via a Prisma transaction as `{ items, page, pageSize, total }`.

### Testing
- Ran lint with `NX_NO_CLOUD=true yarn nx run api:lint` which completed successfully. 
- Ran tests with `NX_NO_CLOUD=true yarn nx run api:test --runInBand` which completed successfully (no tests found, exit code 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1fcb819008320a501e25132134fb8)