### PR TITLE
feat(api): add signed public note share links with expiration and history

### DIFF
--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Note {
   createdAt   DateTime @default(now())
   updatedAt   DateTime @updatedAt
   noteTags    NoteTag[]
+  shareLinks  ShareLink[]
 
   @@index([projectId])
 }
@@ -52,6 +53,24 @@ model User {
   blogPosts     BlogPost[]
   refreshTokens RefreshToken[]
   passwordResetTokens PasswordResetToken[]
+  createdShareLinks ShareLink[] @relation("ShareLinkCreator")
+}
+
+model ShareLink {
+  id              String   @id @default(cuid())
+  noteId          String
+  note            Note     @relation(fields: [noteId], references: [id], onDelete: Cascade)
+  createdByUserId String
+  createdByUser   User     @relation("ShareLinkCreator", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  tokenHash       String
+  expiresAt       DateTime
+  allowSummary    Boolean  @default(false)
+  allowTranscript Boolean  @default(false)
+  createdAt       DateTime @default(now())
+
+  @@index([noteId])
+  @@index([tokenHash])
+  @@index([expiresAt])
 }
 
 model Tag {

--- a/BlaBlaNote/apps/api/src/app/note/dto/create-share-link-response.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/create-share-link-response.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateShareLinkResponseDto {
+  @ApiProperty({ example: 'http://localhost:3001/public/notes/token' })
+  publicUrl: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  expiresAt: Date;
+}

--- a/BlaBlaNote/apps/api/src/app/note/dto/create-share-link.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/create-share-link.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsInt, Max, Min } from 'class-validator';
+
+export class CreateShareLinkDto {
+  @ApiProperty({ example: 24, minimum: 1, maximum: 720 })
+  @IsInt()
+  @Min(1)
+  @Max(720)
+  expiresInHours: number;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  allowSummary: boolean;
+
+  @ApiProperty({ example: true })
+  @IsBoolean()
+  allowTranscript: boolean;
+}

--- a/BlaBlaNote/apps/api/src/app/note/dto/public-shared-note.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/public-shared-note.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PublicSharedNoteDto {
+  @ApiProperty({ example: 'note-id' })
+  noteId: string;
+
+  @ApiPropertyOptional({ example: 'Summary text' })
+  summary?: string;
+
+  @ApiPropertyOptional({ example: 'Transcript text' })
+  transcriptText?: string;
+}

--- a/BlaBlaNote/apps/api/src/app/note/dto/share-history-item.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/note/dto/share-history-item.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ShareHistoryItemDto {
+  @ApiProperty({ example: 'cmabc123' })
+  id: string;
+
+  @ApiProperty({ example: '2026-01-01T00:00:00.000Z' })
+  expiresAt: Date;
+
+  @ApiProperty({ example: true })
+  allowSummary: boolean;
+
+  @ApiProperty({ example: true })
+  allowTranscript: boolean;
+
+  @ApiProperty({ example: '2025-12-31T00:00:00.000Z' })
+  createdAt: Date;
+}

--- a/BlaBlaNote/apps/api/src/app/note/note.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/note/note.controller.ts
@@ -18,6 +18,9 @@ import { ReplaceNoteTagsDto } from './dto/replace-note-tags.dto';
 import { GetNotesQueryDto } from './dto/get-notes-query.dto';
 import { GetNotesResponseDto } from './dto/get-notes-response.dto';
 import { NoteProcessingStatusDto } from './dto/note-processing-status.dto';
+import { CreateShareLinkDto } from './dto/create-share-link.dto';
+import { CreateShareLinkResponseDto } from './dto/create-share-link-response.dto';
+import { ShareHistoryItemDto } from './dto/share-history-item.dto';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -161,4 +164,43 @@ export class NoteController {
     const { method, to, type } = body;
     return this.noteService.shareNote(id, method, to, type);
   }
+
+  @Post(':id/share-link')
+  @ApiOperation({ summary: 'Create a public share link for a note' })
+  @ApiResponse({
+    status: 201,
+    description: 'Share link created successfully',
+    type: CreateShareLinkResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Note not found' })
+  async createShareLink(
+    @Param('id') id: string,
+    @Body() dto: CreateShareLinkDto,
+    @Req() req: Request
+  ) {
+    const user = req.user as AuthUser;
+    return this.noteService.createShareLink(
+      id,
+      user.id,
+      dto.expiresInHours,
+      dto.allowSummary,
+      dto.allowTranscript
+    );
+  }
+
+  @Get(':id/shares')
+  @ApiOperation({ summary: 'Get share link history for a note' })
+  @ApiResponse({
+    status: 200,
+    description: 'Share links fetched successfully',
+    type: [ShareHistoryItemDto],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Note not found' })
+  async getShareHistory(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as AuthUser;
+    return this.noteService.getShareHistory(id, user.id);
+  }
+
 }

--- a/BlaBlaNote/apps/api/src/app/note/note.module.ts
+++ b/BlaBlaNote/apps/api/src/app/note/note.module.ts
@@ -6,10 +6,12 @@ import { AuthModule } from '../auth/auth.module';
 import { DiscordModule } from '../discord/discord.module';
 import { ProjectModule } from '../project/project.module';
 import { WhisperModule } from '../whisper/whisper.module';
+import { PublicNoteController } from './public-note.controller';
+import { ShareController } from './share.controller';
 
 @Module({
   imports: [PrismaModule, AuthModule, DiscordModule, ProjectModule, WhisperModule],
-  controllers: [NoteController],
+  controllers: [NoteController, PublicNoteController, ShareController],
   providers: [NoteService],
 })
 export class NoteModule {}

--- a/BlaBlaNote/apps/api/src/app/note/public-note.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/note/public-note.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { NoteService } from './note.service';
+import { PublicSharedNoteDto } from './dto/public-shared-note.dto';
+
+@ApiTags('Public Notes')
+@Controller('public/notes')
+export class PublicNoteController {
+  constructor(private readonly noteService: NoteService) {}
+
+  @Get(':token')
+  @ApiOperation({ summary: 'Get a shared note by public token' })
+  @ApiResponse({
+    status: 200,
+    description: 'Shared note fetched successfully',
+    type: PublicSharedNoteDto,
+  })
+  @ApiResponse({ status: 404, description: 'Share link not found' })
+  async getSharedNote(@Param('token') token: string) {
+    return this.noteService.getPublicNoteByToken(token);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/note/share.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/note/share.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Delete, Param, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { NoteService } from './note.service';
+
+type AuthUser = {
+  id: string;
+  email: string;
+  role: 'ADMIN' | 'USER';
+};
+
+@ApiTags('Shares')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth()
+@Controller('shares')
+export class ShareController {
+  constructor(private readonly noteService: NoteService) {}
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Revoke a share link' })
+  @ApiResponse({ status: 200, description: 'Share link revoked successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Share link not found' })
+  async revokeShareLink(@Param('id') id: string, @Req() req: Request) {
+    const user = req.user as AuthUser;
+    return this.noteService.revokeShareLink(id, user.id);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a secure share-by-link feature so notes can be shared publicly with a signed token, expiration, and per-link content flags.
- Allow users to view and revoke previously created share links (share history) while protecting raw tokens and enforcing ownership.
- Expose the flows in Swagger to make the new APIs discoverable and typed via DTOs.

### Description
- Added a new Prisma `ShareLink` model with `id`, `noteId`, `createdByUserId`, `tokenHash`, `expiresAt`, `allowSummary`, `allowTranscript`, `createdAt`, and indexes on `noteId`, `tokenHash`, and `expiresAt`, and linked it from `Note` and `User` in `apps/api/prisma/schema.prisma`.
- Implemented secure token generation and storage in `NoteService` using `crypto.randomBytes` for raw tokens and SHA-256 hashing before persisting, plus methods `createShareLink`, `getPublicNoteByToken`, `getShareHistory`, and `revokeShareLink` that enforce expiration and ownership.
- Added DTOs and Swagger-backed request/response types: `CreateShareLinkDto`, `CreateShareLinkResponseDto`, `ShareHistoryItemDto`, and `PublicSharedNoteDto` under `apps/api/src/app/note/dto`.
- Exposed endpoints: authenticated `POST /notes/:id/share-link` (create), authenticated `GET /notes/:id/shares` (history), authenticated `DELETE /shares/:id` (revoke) in controllers and public `GET /public/notes/:token` in `PublicNoteController`, and wired controllers in `NoteModule`.

### Testing
- Attempted `yarn prisma:generate` but it failed because the workspace script expects `prisma/schema.prisma` to exist (missing local path), so client generation was not completed.
- Attempted `npx prisma generate --schema apps/api/prisma/schema.prisma` but it failed due to network/registry restrictions (npm 403), so Prisma client generation could not be validated.
- Attempted `yarn nx run api:build` but it failed because workspace tooling is not installed in this environment (`nx` command not found), so a production build was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ffc06ebc8320bc1ab66ae49ea0d9)