### PR TITLE
feat(api): add admin dashboard users, stats and jobs APIs

### DIFF
--- a/BlaBlaNote/apps/api/src/app/admin/admin.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/admin.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { AdminService } from './admin.service';
+import { GetAdminJobsQueryDto } from './dto/get-admin-jobs-query.dto';
+
+@ApiTags('Admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('ADMIN')
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get admin dashboard stats' })
+  @ApiResponse({ status: 200, description: 'Dashboard stats' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin only' })
+  getStats() {
+    return this.adminService.getStats();
+  }
+
+  @Get('jobs')
+  @ApiOperation({ summary: 'Get jobs queue notes by status' })
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'pageSize', required: false, type: Number })
+  @ApiResponse({ status: 200, description: 'Paginated jobs list' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin only' })
+  getJobs(@Query() query: GetAdminJobsQueryDto) {
+    return this.adminService.getJobs(query);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/admin/admin.module.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/admin.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
 import { AdminUsersController } from './users.controller';
 import { AdminUsersService } from './users.service';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [AdminUsersController],
-  providers: [AdminUsersService],
+  controllers: [AdminController, AdminUsersController],
+  providers: [AdminService, AdminUsersService],
 })
 export class AdminModule {}

--- a/BlaBlaNote/apps/api/src/app/admin/admin.service.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/admin.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common';
+import { NoteStatus } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { GetAdminJobsQueryDto } from './dto/get-admin-jobs-query.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getStats() {
+    const now = new Date();
+    const start = new Date(now);
+    start.setHours(0, 0, 0, 0);
+    start.setDate(start.getDate() - 6);
+
+    const [notesCount, usersCount, sharesCount, failuresCount, notes, users, shares, failures] =
+      await this.prisma.$transaction([
+        this.prisma.note.count(),
+        this.prisma.user.count(),
+        this.prisma.shareLink.count(),
+        this.prisma.note.count({ where: { status: NoteStatus.FAILED } }),
+        this.prisma.note.findMany({
+          where: { createdAt: { gte: start } },
+          select: { createdAt: true },
+        }),
+        this.prisma.user.findMany({
+          where: { createdAt: { gte: start } },
+          select: { createdAt: true },
+        }),
+        this.prisma.shareLink.findMany({
+          where: { createdAt: { gte: start } },
+          select: { createdAt: true },
+        }),
+        this.prisma.note.findMany({
+          where: { createdAt: { gte: start }, status: NoteStatus.FAILED },
+          select: { createdAt: true },
+        }),
+      ]);
+
+    const days = Array.from({ length: 7 }, (_, index) => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + index);
+      return {
+        date: date.toISOString().slice(0, 10),
+        notesCount: 0,
+        usersCount: 0,
+        sharesCount: 0,
+        failuresCount: 0,
+      };
+    });
+
+    const dayMap = new Map(days.map((day) => [day.date, day]));
+
+    for (const item of notes) {
+      const key = item.createdAt.toISOString().slice(0, 10);
+      const day = dayMap.get(key);
+      if (day) day.notesCount += 1;
+    }
+
+    for (const item of users) {
+      const key = item.createdAt.toISOString().slice(0, 10);
+      const day = dayMap.get(key);
+      if (day) day.usersCount += 1;
+    }
+
+    for (const item of shares) {
+      const key = item.createdAt.toISOString().slice(0, 10);
+      const day = dayMap.get(key);
+      if (day) day.sharesCount += 1;
+    }
+
+    for (const item of failures) {
+      const key = item.createdAt.toISOString().slice(0, 10);
+      const day = dayMap.get(key);
+      if (day) day.failuresCount += 1;
+    }
+
+    return {
+      notesCount,
+      usersCount,
+      sharesCount,
+      failuresCount,
+      last7Days: days,
+    };
+  }
+
+  async getJobs(query: GetAdminJobsQueryDto) {
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 20;
+    const where = {
+      status: {
+        in: [NoteStatus.TRANSCRIBING, NoteStatus.SUMMARIZING, NoteStatus.FAILED],
+      },
+    };
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.note.findMany({
+        where,
+        skip: (page - 1) * pageSize,
+        take: pageSize,
+        orderBy: { updatedAt: 'desc' },
+        select: {
+          id: true,
+          userId: true,
+          status: true,
+          errorMessage: true,
+          createdAt: true,
+          updatedAt: true,
+          audioUrl: true,
+        },
+      }),
+      this.prisma.note.count({ where }),
+    ]);
+
+    return {
+      items,
+      page,
+      pageSize,
+      total,
+    };
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/admin/dto/get-admin-jobs-query.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/dto/get-admin-jobs-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class GetAdminJobsQueryDto {
+  @ApiPropertyOptional({ example: 1, default: 1 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  page?: number = 1;
+
+  @ApiPropertyOptional({ example: 20, default: 20, maximum: 100 })
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsOptional()
+  pageSize?: number = 20;
+}

--- a/BlaBlaNote/apps/api/src/app/admin/users.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/admin/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Param, Patch, Query, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiOperation,
@@ -12,7 +12,7 @@ import { RolesGuard } from '../auth/roles.guard';
 import { GetAdminUsersQueryDto } from './dto/get-admin-users-query.dto';
 import { AdminUsersService } from './users.service';
 
-@ApiTags('Admin Users')
+@ApiTags('Admin')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles('ADMIN')
@@ -48,5 +48,14 @@ export class AdminUsersController {
   @ApiResponse({ status: 403, description: 'Forbidden - Admin only' })
   getUsers(@Query() query: GetAdminUsersQueryDto) {
     return this.adminUsersService.getUsers(query);
+  }
+
+  @Patch(':id/block')
+  @ApiOperation({ summary: 'Toggle user blocked status (Admin only)' })
+  @ApiResponse({ status: 200, description: 'User blocked status updated' })
+  @ApiResponse({ status: 403, description: 'Forbidden - Admin only' })
+  @ApiResponse({ status: 404, description: 'User not found' })
+  toggleBlock(@Param('id') id: string) {
+    return this.adminUsersService.toggleBlock(id);
   }
 }


### PR DESCRIPTION
### Motivation
- Provide admin-only endpoints for managing users and observing platform stats and processing jobs, guarded by JWT + role checks and documented in Swagger.

### Description
- Added `AdminController` with `GET /admin/stats` and `GET /admin/jobs` and Swagger metadata and query params, protected with `JwtAuthGuard`, `RolesGuard` and `@Roles('ADMIN')`.
- Implemented `AdminService` with `getStats()` returning `notesCount`, `usersCount`, `sharesCount`, `failuresCount` and `last7Days` aggregates, and `getJobs()` returning paginated notes in statuses `TRANSCRIBING|SUMMARIZING|FAILED`.
- Added pagination DTO `GetAdminJobsQueryDto` and wired new controller/service in `AdminModule`.
- Extended admin users API with `PATCH /admin/users/:id/block` in `AdminUsersController` and `toggleBlock()` in `AdminUsersService` which toggles `UserStatus.SUSPENDED`/`UserStatus.ACTIVE` and returns `{ id, status, blocked }`.

### Testing
- Ran lint: `NX_NO_CLOUD=true yarn nx run api:lint` — succeeded.
- Ran tests: `NX_NO_CLOUD=true yarn nx run api:test` — succeeded (no tests present).
- Built the API: `NX_NO_CLOUD=true yarn nx run api:build` — failed due to pre-existing Prisma client/schema type mismatches in the repository unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2029af44483208817011938dd5295)