### PR TITLE
feat(api): harden auth with refresh token rotation and rate limits

### DIFF
--- a/BlaBlaNote/apps/api/prisma/migrations/20260302000000_refresh_token_sessions/migration.sql
+++ b/BlaBlaNote/apps/api/prisma/migrations/20260302000000_refresh_token_sessions/migration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "RefreshToken"
+ADD COLUMN "sessionId" TEXT,
+ADD COLUMN "userAgent" TEXT,
+ADD COLUMN "ipAddress" TEXT;
+
+UPDATE "RefreshToken"
+SET "sessionId" = "id"
+WHERE "sessionId" IS NULL;
+
+ALTER TABLE "RefreshToken"
+ALTER COLUMN "sessionId" SET NOT NULL;
+
+CREATE INDEX "RefreshToken_sessionId_idx" ON "RefreshToken"("sessionId");

--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -141,19 +141,23 @@ model Project {
 }
 
 model RefreshToken {
-  id        String   @id @default(uuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  tokenHash String   @unique
-  rememberMe Boolean @default(false)
+  id                String        @id @default(uuid())
+  userId            String
+  user              User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  tokenHash         String        @unique
+  sessionId         String
+  userAgent         String?
+  ipAddress         String?
+  rememberMe        Boolean       @default(false)
   replacedByTokenId String?
   replacedByToken   RefreshToken? @relation("RefreshTokenRotation", fields: [replacedByTokenId], references: [id])
   previousToken     RefreshToken[] @relation("RefreshTokenRotation")
-  expiresAt DateTime
-  revokedAt DateTime?
-  createdAt DateTime @default(now())
+  expiresAt         DateTime
+  revokedAt         DateTime?
+  createdAt         DateTime      @default(now())
 
   @@index([userId])
+  @@index([sessionId])
   @@index([expiresAt])
 }
 

--- a/BlaBlaNote/apps/api/src/app/auth/dto/auth-token-response.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/dto/auth-token-response.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class AuthUserDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  firstName!: string;
+
+  @ApiProperty()
+  lastName!: string;
+
+  @ApiProperty({ enum: ['ADMIN', 'USER'] })
+  role!: 'ADMIN' | 'USER';
+
+  @ApiProperty({ nullable: true })
+  termsAcceptedAt!: Date | null;
+
+  @ApiProperty({ nullable: true })
+  termsVersion!: string | null;
+}
+
+export class LoginTokenResponseDto {
+  @ApiProperty()
+  access_token!: string;
+
+  @ApiProperty()
+  refresh_token!: string;
+
+  @ApiProperty()
+  refresh_expires_at!: Date;
+
+  @ApiProperty({ type: AuthUserDto })
+  user!: AuthUserDto;
+}
+
+export class RefreshTokenResponseDto {
+  @ApiProperty()
+  access_token!: string;
+
+  @ApiProperty()
+  refresh_token!: string;
+
+  @ApiProperty()
+  refresh_expires_at!: Date;
+}
+
+export class LogoutResponseDto {
+  @ApiProperty()
+  success!: boolean;
+}
+
+export class ErrorResponseDto {
+  @ApiProperty()
+  statusCode!: number;
+
+  @ApiProperty()
+  message!: string;
+
+  @ApiProperty()
+  error!: string;
+}

--- a/BlaBlaNote/apps/api/src/app/auth/refresh-token.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/refresh-token.service.ts
@@ -10,6 +10,10 @@ export class RefreshTokenService {
     return crypto.randomBytes(48).toString('hex');
   }
 
+  generateSessionId() {
+    return crypto.randomUUID();
+  }
+
   hashToken(token: string) {
     return crypto.createHash('sha256').update(token).digest('hex');
   }
@@ -19,6 +23,9 @@ export class RefreshTokenService {
     rawToken: string;
     expiresAt: Date;
     rememberMe: boolean;
+    sessionId: string;
+    userAgent?: string;
+    ipAddress?: string;
     replacedByTokenId?: string;
   }) {
     return this.prisma.refreshToken.create({
@@ -27,6 +34,9 @@ export class RefreshTokenService {
         tokenHash: this.hashToken(params.rawToken),
         expiresAt: params.expiresAt,
         rememberMe: params.rememberMe,
+        sessionId: params.sessionId,
+        userAgent: params.userAgent,
+        ipAddress: params.ipAddress,
         replacedByTokenId: params.replacedByTokenId,
       },
     });
@@ -56,6 +66,9 @@ export class RefreshTokenService {
     currentUserId: string;
     rememberMe: boolean;
     expiresAt: Date;
+    sessionId: string;
+    userAgent?: string;
+    ipAddress?: string;
   }) {
     const newRawToken = this.generateRawToken();
     const newToken = await this.prisma.refreshToken.create({
@@ -64,6 +77,9 @@ export class RefreshTokenService {
         tokenHash: this.hashToken(newRawToken),
         expiresAt: params.expiresAt,
         rememberMe: params.rememberMe,
+        sessionId: params.sessionId,
+        userAgent: params.userAgent,
+        ipAddress: params.ipAddress,
       },
     });
 


### PR DESCRIPTION
### Motivation
- Improve refresh token security by storing per-session/device metadata and enabling rotation to prevent token reuse. 
- Provide logout revocation and make refresh/login endpoints resilient to abuse by adding IP-based rate limiting. 
- Surface token response schemas and error shapes in Swagger for clearer client integration and testing.

### Description
- Add `sessionId`, `userAgent`, and `ipAddress` to the `RefreshToken` model in `apps/api/prisma/schema.prisma` and include a SQL migration `apps/api/prisma/migrations/20260302000000_refresh_token_sessions/migration.sql` that backfills and indexes `sessionId`.
- Extend `RefreshTokenService` (`apps/api/src/app/auth/refresh-token.service.ts`) to generate session IDs and persist `sessionId`, `userAgent`, and `ipAddress`, and update `rotateToken` to create a new token record and revoke the previous one (rotation).
- Update `AuthService` (`apps/api/src/app/auth/auth.service.ts`) to accept structured params for `login` and `refresh`, apply in-memory IP rate limits via `hitRateLimit`, store session metadata on create, perform rotation on refresh, and revoke a token on logout.
- Update `AuthController` (`apps/api/src/app/auth/auth.controller.ts`) to pass `ip` and `user-agent` into service calls, continue setting/clearing the refresh cookie, and add Swagger response/error annotations for `POST /auth/login`, `POST /auth/refresh`, and `POST /auth/logout`.
- Add Swagger DTOs for token responses and errors in `apps/api/src/app/auth/dto/auth-token-response.dto.ts` to document the new payloads and error shapes.

### Testing
- Ran Prisma client generation with `npx prisma generate --schema apps/api/prisma/schema.prisma` which completed successfully. 
- Built the API with `NX_NO_CLOUD=true yarn nx build api` which completed successfully. 
- Running the repo `yarn prisma:generate` script failed in this environment due to the repository script copying to `prisma/schema.prisma` path that does not exist, which does not affect the included schema changes (manual `npx prisma generate` was used above).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a203fb911c8320a6c9cbc89cf9ebbe)