### PR TITLE
feat(api): add health endpoint and request logging middleware

### DIFF
--- a/BlaBlaNote/apps/api/src/app/app.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/app.controller.ts
@@ -1,6 +1,6 @@
 import { Controller, Get } from '@nestjs/common';
 import { AppService } from './app.service';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 
 @ApiTags('App')
 @Controller()
@@ -12,5 +12,23 @@ export class AppController {
   @ApiResponse({ status: 200, description: 'Application is running' })
   getData() {
     return this.appService.getData();
+  }
+
+  @Get('health')
+  @ApiOperation({ summary: 'Get service health status' })
+  @ApiResponse({
+    status: 200,
+    description: 'Service and database are healthy',
+    schema: {
+      type: 'object',
+      properties: {
+        status: { type: 'string', example: 'ok' },
+        api: { type: 'string', example: 'up' },
+        db: { type: 'string', example: 'up' },
+      },
+    },
+  })
+  getHealth() {
+    return this.appService.getHealth();
   }
 }

--- a/BlaBlaNote/apps/api/src/app/app.service.ts
+++ b/BlaBlaNote/apps/api/src/app/app.service.ts
@@ -1,8 +1,21 @@
 import { Injectable } from '@nestjs/common';
+import { PrismaService } from './prisma/prisma.service';
 
 @Injectable()
 export class AppService {
+  constructor(private readonly prisma: PrismaService) {}
+
   getData(): { message: string } {
     return { message: 'Hello API' };
+  }
+
+  async getHealth() {
+    await this.prisma.$queryRaw`SELECT 1`;
+
+    return {
+      status: 'ok',
+      api: 'up',
+      db: 'up',
+    };
   }
 }

--- a/BlaBlaNote/apps/api/src/app/observability/request-logging.middleware.ts
+++ b/BlaBlaNote/apps/api/src/app/observability/request-logging.middleware.ts
@@ -1,0 +1,33 @@
+import { Logger } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+
+const logger = new Logger('HTTP');
+
+export function requestLoggingMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+) {
+  const start = Date.now();
+  const requestIdHeader = req.header('x-request-id');
+  const requestId = requestIdHeader || randomUUID();
+
+  res.setHeader('x-request-id', requestId);
+
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    const user = req.user as { id?: string; sub?: string } | undefined;
+
+    logger.log({
+      requestId,
+      method: req.method,
+      path: req.originalUrl || req.url,
+      status: res.statusCode,
+      duration,
+      userId: user?.id || user?.sub || null,
+    });
+  });
+
+  next();
+}

--- a/BlaBlaNote/apps/api/src/main.ts
+++ b/BlaBlaNote/apps/api/src/main.ts
@@ -8,6 +8,7 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import 'dotenv/config';
+import { requestLoggingMiddleware } from './app/observability/request-logging.middleware';
 
 async function bootstrap() {
   const config = new DocumentBuilder()
@@ -18,6 +19,8 @@ async function bootstrap() {
     .build();
 
   const app = await NestFactory.create(AppModule);
+
+  app.use(requestLoggingMiddleware);
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
### Motivation
- Provide basic observability by exposing a lightweight health check that verifies API and DB connectivity.
- Capture per-request telemetry (request id, method, path, status, duration) to aid debugging and tracing.
- Surface the new health endpoint in API documentation so consumers and monitoring systems can discover it.

### Description
- Added a global request logging middleware at `apps/api/src/app/observability/request-logging.middleware.ts` that assigns/propagates `x-request-id` and logs `method`, `path`, `status`, `duration`, and `userId` when present.
- Registered the middleware in the bootstrap flow in `apps/api/src/main.ts` via `app.use(requestLoggingMiddleware)`.
- Added `GET /health` in `apps/api/src/app/app.controller.ts` and documented its response schema with Swagger annotations.
- Implemented `getHealth()` in `apps/api/src/app/app.service.ts` which performs a simple Prisma round-trip (`SELECT 1`) and returns a structured `{ status, api, db }` payload.

### Testing
- Ran `yarn prettier --check apps/api/src/main.ts apps/api/src/app/app.controller.ts apps/api/src/app/app.service.ts apps/api/src/app/observability/request-logging.middleware.ts` and it passed.
- Ran `yarn tsc -p apps/api/tsconfig.app.json --noEmit` which failed with existing type errors in other files related to Prisma model mismatches (unrelated to these changes).
- Ran `yarn nx run api:build` which reported the build target ran but the command exited non-zero in this environment due to an Nx Cloud client download issue.
- Ran `yarn nx run api:test --passWithNoTests` which similarly reported the test target run but exited non-zero due to the Nx Cloud client download issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2065e59448320ae74fd5cd3b8844f)