### PR TITLE
feat(api): add GDPR /me export and account deletion endpoints

### DIFF
--- a/BlaBlaNote/apps/api/src/app/user/dto/export-user-data.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/user/dto/export-user-data.dto.ts
@@ -1,0 +1,163 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+class ExportTagDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  slug: string;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}
+
+class ExportShareLinkMetadataDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  noteId: string;
+
+  @ApiProperty()
+  expiresAt: Date;
+
+  @ApiProperty()
+  allowSummary: boolean;
+
+  @ApiProperty()
+  allowTranscript: boolean;
+
+  @ApiProperty()
+  createdAt: Date;
+}
+
+class ExportProjectDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}
+
+class ExportNoteDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  projectId: string | null;
+
+  @ApiProperty()
+  text: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  transcriptText: string | null;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  errorMessage: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  summary: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  translation: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  audioUrl: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+
+  @ApiProperty({ type: () => [ExportTagDto] })
+  tags: ExportTagDto[];
+
+  @ApiProperty({ type: () => [ExportShareLinkMetadataDto] })
+  shareLinks: ExportShareLinkMetadataDto[];
+}
+
+class ExportUserProfileDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  firstName: string;
+
+  @ApiProperty()
+  lastName: string;
+
+  @ApiProperty()
+  email: string;
+
+  @ApiProperty()
+  role: string;
+
+  @ApiProperty()
+  status: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  termsAcceptedAt: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  termsVersion: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  lastLoginAt: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  suspendedAt: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  deletedAt: Date | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  plan: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  priceCents: number | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  currency: string | null;
+
+  @ApiProperty({ required: false, nullable: true })
+  billingStatus: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  @ApiProperty()
+  updatedAt: Date;
+}
+
+export class ExportUserDataDto {
+  @ApiProperty({ type: () => ExportUserProfileDto })
+  profile: ExportUserProfileDto;
+
+  @ApiProperty({ type: () => [ExportNoteDto] })
+  notes: ExportNoteDto[];
+
+  @ApiProperty({ type: () => [ExportProjectDto] })
+  projects: ExportProjectDto[];
+
+  @ApiProperty({ type: () => [ExportTagDto] })
+  tags: ExportTagDto[];
+
+  @ApiProperty({ type: () => [ExportShareLinkMetadataDto] })
+  shareLinks: ExportShareLinkMetadataDto[];
+}

--- a/BlaBlaNote/apps/api/src/app/user/me.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/user/me.controller.ts
@@ -1,0 +1,55 @@
+import { Controller, Delete, Get, Req, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ExportUserDataDto } from './dto/export-user-data.dto';
+import { UserService } from './user.service';
+
+@Controller('me')
+export class MeController {
+  constructor(private readonly userService: UserService) {}
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Get('export')
+  @ApiOperation({
+    summary: 'Export my account data',
+    description:
+      'Returns the authenticated user profile with notes, projects, tags, and share links metadata.',
+  })
+  @ApiOkResponse({ type: ExportUserDataDto })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiNotFoundResponse({ description: 'User not found' })
+  exportMyData(@Req() req: { user: { id: string } }) {
+    return this.userService.exportUserData(req.user.id);
+  }
+
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @Delete()
+  @ApiOperation({
+    summary: 'Delete my account and owned data',
+    description:
+      'Permanently deletes the authenticated user and all owned data through database cascades.',
+  })
+  @ApiOkResponse({
+    description: 'Account and owned data deleted successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiNotFoundResponse({ description: 'User not found' })
+  async deleteMyAccount(@Req() req: { user: { id: string } }) {
+    await this.userService.deleteMyAccount(req.user.id);
+    return { success: true };
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/user/user.module.ts
+++ b/BlaBlaNote/apps/api/src/app/user/user.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
+import { MeController } from './me.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 import { UserService } from './user.service';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [PrismaModule, AuthModule],
-  controllers: [UserController],
+  controllers: [UserController, MeController],
   providers: [UserService],
   exports: [UserService],
 })

--- a/BlaBlaNote/apps/api/src/app/user/user.service.ts
+++ b/BlaBlaNote/apps/api/src/app/user/user.service.ts
@@ -61,6 +61,100 @@ export class UserService {
       },
     });
   }
+
+  async exportUserData(userId: string) {
+    const user = await this.prisma.user.findUnique({
+      where: { id: userId },
+      include: {
+        notes: {
+          include: {
+            noteTags: {
+              include: {
+                tag: true,
+              },
+            },
+            shareLinks: {
+              select: {
+                id: true,
+                noteId: true,
+                expiresAt: true,
+                allowSummary: true,
+                allowTranscript: true,
+                createdAt: true,
+              },
+            },
+          },
+        },
+        projects: true,
+        tags: true,
+        createdShareLinks: {
+          select: {
+            id: true,
+            noteId: true,
+            expiresAt: true,
+            allowSummary: true,
+            allowTranscript: true,
+            createdAt: true,
+          },
+        },
+      },
+    });
+
+    if (!user) throw new NotFoundException('User not found');
+
+    return {
+      profile: {
+        id: user.id,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        email: user.email,
+        role: user.role,
+        status: user.status,
+        termsAcceptedAt: user.termsAcceptedAt,
+        termsVersion: user.termsVersion,
+        lastLoginAt: user.lastLoginAt,
+        suspendedAt: user.suspendedAt,
+        deletedAt: user.deletedAt,
+        plan: user.plan,
+        priceCents: user.priceCents,
+        currency: user.currency,
+        billingStatus: user.billingStatus,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      },
+      notes: user.notes.map((note) => ({
+        id: note.id,
+        projectId: note.projectId,
+        text: note.text,
+        transcriptText: note.transcriptText,
+        status: note.status,
+        errorMessage: note.errorMessage,
+        summary: note.summary,
+        translation: note.translation,
+        audioUrl: note.audioUrl,
+        createdAt: note.createdAt,
+        updatedAt: note.updatedAt,
+        tags: note.noteTags.map((noteTag) => ({
+          id: noteTag.tag.id,
+          name: noteTag.tag.name,
+          slug: noteTag.tag.slug,
+          createdAt: noteTag.tag.createdAt,
+          updatedAt: noteTag.tag.updatedAt,
+        })),
+        shareLinks: note.shareLinks,
+      })),
+      projects: user.projects,
+      tags: user.tags,
+      shareLinks: user.createdShareLinks,
+    };
+  }
+
+  async deleteMyAccount(userId: string) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) throw new NotFoundException('User not found');
+    await this.prisma.user.delete({ where: { id: userId } });
+  }
+
   async deleteUser(id: string) {
     const user = await this.prisma.user.findUnique({ where: { id } });
     if (!user) throw new NotFoundException('User not found');


### PR DESCRIPTION
### Motivation
- Provide user privacy endpoints to allow authenticated users to export their account data and permanently delete their account and owned data to satisfy GDPR-style requirements.
- No external skills were used during this change.

### Description
- Added `MeController` with `GET /me/export` (returns profile, notes, projects, tags, and share-links metadata) and `DELETE /me` (deletes authenticated user and owned data).
- Added `ExportUserDataDto` with nested DTOs to document the export payload for Swagger/OpenAPI.
- Extended `UserService` with `exportUserData(userId)` to assemble the export payload (includes note tags and share link metadata) and `deleteMyAccount(userId)` that deletes the user (relying on existing Prisma cascade relations).
- Registered `MeController` in `UserModule`; no Prisma schema migration was required because cascade delete rules already exist for the relevant relations.

### Testing
- Ran `yarn nx build api`; target build reported success but the command exited non-zero due to Nx Cloud client download behavior in this environment (build target itself executed).
- Ran `yarn tsc -p apps/api/tsconfig.app.json --noEmit`; TypeScript check failed due to pre-existing Prisma client generation/type issues unrelated to these changes (missing generated Prisma types), so full typecheck did not succeed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a207aad588832095bc2afe2677b80c)