### PR TITLE
feat: implement user profile & settings (backend + frontend)

### DIFF
--- a/BlaBlaNote/apps/api/prisma/migrations/20260303000000_profile_settings/migration.sql
+++ b/BlaBlaNote/apps/api/prisma/migrations/20260303000000_profile_settings/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "User"
+  ALTER COLUMN "role" TYPE TEXT USING "role"::text,
+  ALTER COLUMN "role" SET DEFAULT 'USER',
+  ADD COLUMN "isBlocked" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "avatarUrl" TEXT,
+  ADD COLUMN "language" TEXT NOT NULL DEFAULT 'en',
+  ADD COLUMN "theme" TEXT NOT NULL DEFAULT 'light',
+  ADD COLUMN "notificationsEnabled" BOOLEAN NOT NULL DEFAULT true;
+
+DROP TYPE IF EXISTS "Role";
+
+CREATE INDEX "User_role_idx" ON "User"("role");
+CREATE INDEX "User_isBlocked_idx" ON "User"("isBlocked");
+CREATE INDEX "User_createdAt_idx" ON "User"("createdAt");

--- a/BlaBlaNote/apps/api/prisma/schema.prisma
+++ b/BlaBlaNote/apps/api/prisma/schema.prisma
@@ -29,12 +29,17 @@ model Note {
 }
 
 model User {
-  id            String         @id @default(uuid())
+  id            String         @id @default(cuid())
   firstName     String
   lastName      String
   email         String         @unique
   password      String
-  role          Role           @default(USER)
+  role          String         @default("USER")
+  isBlocked     Boolean        @default(false)
+  avatarUrl     String?
+  language      String         @default("en")
+  theme         String         @default("light")
+  notificationsEnabled Boolean @default(true)
   status        UserStatus     @default(PENDING)
   termsAcceptedAt DateTime?
   termsVersion   String?
@@ -54,6 +59,10 @@ model User {
   refreshTokens RefreshToken[]
   passwordResetTokens PasswordResetToken[]
   createdShareLinks ShareLink[] @relation("ShareLinkCreator")
+
+  @@index([role])
+  @@index([isBlocked])
+  @@index([createdAt])
 }
 
 model ShareLink {
@@ -172,11 +181,6 @@ model PasswordResetToken {
 
   @@index([userId])
   @@index([expiresAt])
-}
-
-enum Role {
-  USER
-  ADMIN
 }
 
 enum UserStatus {

--- a/BlaBlaNote/apps/api/src/app/app.module.ts
+++ b/BlaBlaNote/apps/api/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { AdminModule } from './admin/admin.module';
 import { ProjectModule } from './project/project.module';
 import { BlogModule } from './blog/blog.module';
 import { TagModule } from './tag/tag.module';
+import { ProfileModule } from './profile/profile.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { TagModule } from './tag/tag.module';
     ProjectModule,
     BlogModule,
     TagModule,
+    ProfileModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
   private generateAccessToken(user: {
     id: string;
     email: string;
-    role: 'ADMIN' | 'USER';
+    role: string;
   }) {
     const payload = { sub: user.id, email: user.email, role: user.role };
     return this.jwtService.sign(payload, {

--- a/BlaBlaNote/apps/api/src/app/auth/jwt.strategy.ts
+++ b/BlaBlaNote/apps/api/src/app/auth/jwt.strategy.ts
@@ -16,7 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   async validate(payload: {
     sub: string;
     email: string;
-    role: 'ADMIN' | 'USER';
+    role: string;
   }) {
     return {
       id: payload.sub,

--- a/BlaBlaNote/apps/api/src/app/profile/dto/change-password.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/dto/change-password.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, MinLength } from 'class-validator';
+
+export class ChangePasswordDto {
+  @ApiProperty({ example: 'current-password' })
+  @IsString()
+  currentPassword!: string;
+
+  @ApiProperty({ example: 'new-password-123' })
+  @IsString()
+  @MinLength(8)
+  newPassword!: string;
+}

--- a/BlaBlaNote/apps/api/src/app/profile/dto/profile-response.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/dto/profile-response.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ProfileResponseDto {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  firstName!: string;
+
+  @ApiProperty()
+  lastName!: string;
+
+  @ApiProperty()
+  role!: string;
+
+  @ApiProperty()
+  isBlocked!: boolean;
+
+  @ApiProperty({ nullable: true })
+  avatarUrl!: string | null;
+
+  @ApiProperty()
+  language!: string;
+
+  @ApiProperty({ enum: ['light', 'dark'] })
+  theme!: 'light' | 'dark';
+
+  @ApiProperty()
+  notificationsEnabled!: boolean;
+
+  @ApiProperty()
+  createdAt!: Date;
+
+  @ApiProperty()
+  updatedAt!: Date;
+}

--- a/BlaBlaNote/apps/api/src/app/profile/dto/update-profile.dto.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/dto/update-profile.dto.ts
@@ -1,0 +1,32 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsIn, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ example: 'John' })
+  @IsString()
+  @MaxLength(100)
+  @IsOptional()
+  firstName?: string;
+
+  @ApiPropertyOptional({ example: 'Doe' })
+  @IsString()
+  @MaxLength(100)
+  @IsOptional()
+  lastName?: string;
+
+  @ApiPropertyOptional({ example: 'en' })
+  @IsString()
+  @MaxLength(10)
+  @IsOptional()
+  language?: string;
+
+  @ApiPropertyOptional({ example: 'dark', enum: ['light', 'dark'] })
+  @IsIn(['light', 'dark'])
+  @IsOptional()
+  theme?: 'light' | 'dark';
+
+  @ApiPropertyOptional({ example: true })
+  @IsBoolean()
+  @IsOptional()
+  notificationsEnabled?: boolean;
+}

--- a/BlaBlaNote/apps/api/src/app/profile/profile.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/profile.controller.ts
@@ -1,0 +1,121 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Patch,
+  Post,
+  Req,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiForbiddenResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { ProfileService } from './profile.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { ProfileResponseDto } from './dto/profile-response.dto';
+
+@ApiTags('Profile')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller()
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get current authenticated profile' })
+  @ApiOkResponse({ type: ProfileResponseDto })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  @ApiForbiddenResponse({ description: 'Forbidden' })
+  getMe(@Req() req: { user: { id: string } }) {
+    return this.profileService.getMe(req.user.id);
+  }
+
+  @Patch('me')
+  @ApiOperation({ summary: 'Update current authenticated profile' })
+  @ApiOkResponse({ type: ProfileResponseDto })
+  @ApiBadRequestResponse({ description: 'Validation failed' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  updateMe(@Req() req: { user: { id: string } }, @Body() dto: UpdateProfileDto) {
+    return this.profileService.updateMe(req.user.id, dto);
+  }
+
+  @Patch('me/password')
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Change current authenticated password' })
+  @ApiBody({ type: ChangePasswordDto })
+  @ApiOkResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+      },
+    },
+  })
+  @ApiBadRequestResponse({ description: 'Current password invalid or validation failed' })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  changePassword(@Req() req: { user: { id: string } }, @Body() dto: ChangePasswordDto) {
+    return this.profileService.changePassword(req.user.id, dto);
+  }
+
+  @Delete('me')
+  @ApiOperation({ summary: 'Delete current authenticated account' })
+  @ApiOkResponse({
+    schema: {
+      type: 'object',
+      properties: {
+        success: { type: 'boolean', example: true },
+        message: { type: 'string', example: 'Account deleted successfully' },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
+  deleteMe(@Req() req: { user: { id: string } }) {
+    return this.profileService.deleteMe(req.user.id);
+  }
+
+  @Post('me/avatar')
+  @UseInterceptors(
+    FileInterceptor('avatar', {
+      storage: memoryStorage(),
+      limits: { fileSize: 5 * 1024 * 1024 },
+    })
+  )
+  @ApiOperation({ summary: 'Upload profile avatar' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        avatar: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+      required: ['avatar'],
+    },
+  })
+  @ApiOkResponse({ type: ProfileResponseDto })
+  @ApiBadRequestResponse({ description: 'Invalid file or bad request' })
+  uploadAvatar(
+    @Req() req: { user: { id: string } },
+    @UploadedFile() file: Express.Multer.File
+  ) {
+    return this.profileService.uploadAvatar(req.user.id, file);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/profile/profile.module.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/profile.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+import { ProfileStorageService } from './profile.storage.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProfileController],
+  providers: [ProfileService, ProfileStorageService],
+})
+export class ProfileModule {}

--- a/BlaBlaNote/apps/api/src/app/profile/profile.service.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/profile.service.ts
@@ -1,0 +1,149 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import * as bcrypt from 'bcrypt';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { ProfileStorageService } from './profile.storage.service';
+
+@Injectable()
+export class ProfileService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly profileStorageService: ProfileStorageService
+  ) {}
+
+  private toSafeUser(user: {
+    id: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    role: string;
+    isBlocked: boolean;
+    avatarUrl: string | null;
+    language: string;
+    theme: string;
+    notificationsEnabled: boolean;
+    createdAt: Date;
+    updatedAt: Date;
+  }) {
+    return {
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      role: user.role,
+      isBlocked: user.isBlocked,
+      avatarUrl: user.avatarUrl,
+      language: user.language,
+      theme: user.theme,
+      notificationsEnabled: user.notificationsEnabled,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
+
+  async getMe(userId: string) {
+    if (!userId) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (user.isBlocked) {
+      throw new ForbiddenException('User is blocked');
+    }
+
+    return this.toSafeUser(user);
+  }
+
+  async updateMe(userId: string, dto: UpdateProfileDto) {
+    if (!userId) {
+      throw new UnauthorizedException('Unauthorized');
+    }
+
+    const existingUser = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!existingUser) {
+      throw new NotFoundException('User not found');
+    }
+
+    const user = await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        firstName: dto.firstName,
+        lastName: dto.lastName,
+        language: dto.language,
+        theme: dto.theme,
+        notificationsEnabled: dto.notificationsEnabled,
+      },
+    });
+
+    return this.toSafeUser(user);
+  }
+
+  async changePassword(userId: string, dto: ChangePasswordDto) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const isValidCurrentPassword = await bcrypt.compare(dto.currentPassword, user.password);
+    if (!isValidCurrentPassword) {
+      throw new BadRequestException('Current password is invalid');
+    }
+
+    const isSamePassword = await bcrypt.compare(dto.newPassword, user.password);
+    if (isSamePassword) {
+      throw new BadRequestException('New password must be different from current password');
+    }
+
+    const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { password: hashedPassword },
+    });
+
+    return { success: true };
+  }
+
+  async deleteMe(userId: string) {
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    await this.prisma.user.delete({ where: { id: userId } });
+
+    return { success: true, message: 'Account deleted successfully' };
+  }
+
+  async uploadAvatar(userId: string, file: Express.Multer.File) {
+    if (!file) {
+      throw new BadRequestException('Avatar file is required');
+    }
+
+    const user = await this.prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const avatarUrl = await this.profileStorageService.uploadAvatar(userId, file);
+
+    const updatedUser = await this.prisma.user.update({
+      where: { id: userId },
+      data: { avatarUrl },
+    });
+
+    return this.toSafeUser(updatedUser);
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/profile/profile.storage.service.ts
+++ b/BlaBlaNote/apps/api/src/app/profile/profile.storage.service.ts
@@ -1,0 +1,40 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class ProfileStorageService {
+  private readonly uploadBaseUrl = process.env.S3_UPLOAD_BASE_URL || '';
+  private readonly publicBaseUrl = process.env.S3_PUBLIC_BASE_URL || '';
+  private readonly uploadToken = process.env.S3_UPLOAD_TOKEN || '';
+
+  async uploadAvatar(userId: string, file: Express.Multer.File) {
+    if (!this.uploadBaseUrl || !this.publicBaseUrl) {
+      throw new BadRequestException('S3 storage configuration is incomplete');
+    }
+
+    if (!file.mimetype.startsWith('image/')) {
+      throw new BadRequestException('Only image files are allowed');
+    }
+
+    const extension = file.originalname.includes('.')
+      ? file.originalname.split('.').pop()?.toLowerCase()
+      : 'jpg';
+    const key = `avatars/${userId}/${randomUUID()}.${extension}`;
+    const uploadUrl = `${this.uploadBaseUrl.replace(/\/$/, '')}/${key}`;
+
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': file.mimetype,
+        ...(this.uploadToken ? { Authorization: `Bearer ${this.uploadToken}` } : {}),
+      },
+      body: file.buffer,
+    });
+
+    if (!response.ok) {
+      throw new BadRequestException('Avatar upload failed');
+    }
+
+    return `${this.publicBaseUrl.replace(/\/$/, '')}/${key}`;
+  }
+}

--- a/BlaBlaNote/apps/api/src/app/user/me.controller.ts
+++ b/BlaBlaNote/apps/api/src/app/user/me.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Get, Req, UseGuards } from '@nestjs/common';
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiNotFoundResponse,
@@ -27,29 +27,5 @@ export class MeController {
   @ApiNotFoundResponse({ description: 'User not found' })
   exportMyData(@Req() req: { user: { id: string } }) {
     return this.userService.exportUserData(req.user.id);
-  }
-
-  @ApiBearerAuth()
-  @UseGuards(JwtAuthGuard)
-  @Delete()
-  @ApiOperation({
-    summary: 'Delete my account and owned data',
-    description:
-      'Permanently deletes the authenticated user and all owned data through database cascades.',
-  })
-  @ApiOkResponse({
-    description: 'Account and owned data deleted successfully',
-    schema: {
-      type: 'object',
-      properties: {
-        success: { type: 'boolean', example: true },
-      },
-    },
-  })
-  @ApiUnauthorizedResponse({ description: 'Unauthorized' })
-  @ApiNotFoundResponse({ description: 'User not found' })
-  async deleteMyAccount(@Req() req: { user: { id: string } }) {
-    await this.userService.deleteMyAccount(req.user.id);
-    return { success: true };
   }
 }

--- a/BlaBlaNote/apps/front/src/api/profileApi.ts
+++ b/BlaBlaNote/apps/front/src/api/profileApi.ts
@@ -1,0 +1,30 @@
+import { http } from './http';
+import {
+  ChangePasswordPayload,
+  ProfileUser,
+  UpdateProfilePayload,
+} from '../types/profile.types';
+
+export const profileApi = {
+  getMe() {
+    return http.get<ProfileUser>('/me').then((res) => res.data);
+  },
+  updateMe(payload: UpdateProfilePayload) {
+    return http.patch<ProfileUser>('/me', payload).then((res) => res.data);
+  },
+  changePassword(payload: ChangePasswordPayload) {
+    return http.patch<{ success: boolean }>('/me/password', payload).then((res) => res.data);
+  },
+  uploadAvatar(file: File) {
+    const formData = new FormData();
+    formData.append('avatar', file);
+    return http
+      .post<ProfileUser>('/me/avatar', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      .then((res) => res.data);
+  },
+  deleteMe() {
+    return http.delete<{ success: boolean; message: string }>('/me').then((res) => res.data);
+  },
+};

--- a/BlaBlaNote/apps/front/src/components/profile/FormMessage.tsx
+++ b/BlaBlaNote/apps/front/src/components/profile/FormMessage.tsx
@@ -1,0 +1,17 @@
+export function FormMessage({
+  type,
+  message,
+}: {
+  type: 'success' | 'error';
+  message: string | null;
+}) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p className={type === 'success' ? 'text-sm text-emerald-700' : 'text-sm text-red-600'}>
+      {message}
+    </p>
+  );
+}

--- a/BlaBlaNote/apps/front/src/components/profile/SettingsField.tsx
+++ b/BlaBlaNote/apps/front/src/components/profile/SettingsField.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+
+export function SettingsField({
+  label,
+  children,
+}: PropsWithChildren<{ label: string }>) {
+  return (
+    <label className="grid gap-2 text-sm font-medium text-slate-700">
+      <span>{label}</span>
+      {children}
+    </label>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/ProfilePage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/ProfilePage.tsx
@@ -1,0 +1,222 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { profileApi } from '../api/profileApi';
+import { FormMessage } from '../components/profile/FormMessage';
+import { Loader } from '../components/ui/Loader';
+import { useAuth } from '../hooks/useAuth';
+import { useNavigate } from '../router/router';
+import { ApiError } from '../types/api.types';
+import { ProfileUser } from '../types/profile.types';
+
+export function ProfilePage() {
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState<ProfileUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
+  const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [currentPassword, setCurrentPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    profileApi
+      .getMe()
+      .then((user) => {
+        setProfile(user);
+        setFirstName(user.firstName);
+        setLastName(user.lastName);
+      })
+      .catch((error: ApiError) => {
+        setErrorMessage(error.message);
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  async function onSaveProfile(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsSaving(true);
+
+    try {
+      const user = await profileApi.updateMe({ firstName, lastName });
+      setProfile(user);
+      setSuccessMessage('Profile updated successfully.');
+    } catch (error) {
+      setErrorMessage((error as ApiError).message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function onAvatarUpload(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const input = event.currentTarget.elements.namedItem('avatar') as HTMLInputElement;
+    const file = input.files?.[0];
+
+    if (!file) {
+      setErrorMessage('Please select an avatar image.');
+      return;
+    }
+
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsUploadingAvatar(true);
+
+    try {
+      const user = await profileApi.uploadAvatar(file);
+      setProfile(user);
+      setSuccessMessage('Avatar uploaded successfully.');
+      input.value = '';
+    } catch (error) {
+      setErrorMessage((error as ApiError).message);
+    } finally {
+      setIsUploadingAvatar(false);
+    }
+  }
+
+  async function onChangePassword(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsChangingPassword(true);
+
+    try {
+      await profileApi.changePassword({ currentPassword, newPassword });
+      setCurrentPassword('');
+      setNewPassword('');
+      setSuccessMessage('Password changed successfully.');
+    } catch (error) {
+      setErrorMessage((error as ApiError).message);
+    } finally {
+      setIsChangingPassword(false);
+    }
+  }
+
+  async function onDeleteAccount() {
+    if (!window.confirm('Are you sure you want to permanently delete your account?')) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setErrorMessage(null);
+
+    try {
+      await profileApi.deleteMe();
+      await logout();
+      navigate('/login', { replace: true });
+    } catch (error) {
+      setErrorMessage((error as ApiError).message);
+      setIsDeleting(false);
+    }
+  }
+
+  if (isLoading) {
+    return <Loader label="Loading profile..." />;
+  }
+
+  if (!profile) {
+    return <p className="text-red-600">Failed to load profile.</p>;
+  }
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-slate-900">Profile</h1>
+      <FormMessage type="success" message={successMessage} />
+      <FormMessage type="error" message={errorMessage} />
+
+      <article className="space-y-4 rounded-xl border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold">Account information</h2>
+        <p className="text-sm text-slate-600">{profile.email}</p>
+        {profile.avatarUrl ? (
+          <img
+            src={profile.avatarUrl}
+            alt="Avatar"
+            className="h-20 w-20 rounded-full border border-slate-200 object-cover"
+          />
+        ) : null}
+        <form className="grid gap-3" onSubmit={onSaveProfile}>
+          <input
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={firstName}
+            onChange={(event) => setFirstName(event.target.value)}
+            placeholder="First name"
+            required
+          />
+          <input
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={lastName}
+            onChange={(event) => setLastName(event.target.value)}
+            placeholder="Last name"
+            required
+          />
+          <button
+            type="submit"
+            className="rounded-lg bg-slate-900 px-4 py-2 text-white"
+            disabled={isSaving}
+          >
+            {isSaving ? 'Saving...' : 'Save profile'}
+          </button>
+        </form>
+
+        <form className="grid gap-3" onSubmit={onAvatarUpload}>
+          <input name="avatar" type="file" accept="image/*" className="block w-full text-sm" />
+          <button
+            type="submit"
+            className="rounded-lg border border-slate-300 px-4 py-2 text-slate-900"
+            disabled={isUploadingAvatar}
+          >
+            {isUploadingAvatar ? 'Uploading...' : 'Upload avatar'}
+          </button>
+        </form>
+      </article>
+
+      <article className="space-y-4 rounded-xl border border-slate-200 bg-white p-6">
+        <h2 className="text-lg font-semibold">Change password</h2>
+        <form className="grid gap-3" onSubmit={onChangePassword}>
+          <input
+            type="password"
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={currentPassword}
+            onChange={(event) => setCurrentPassword(event.target.value)}
+            placeholder="Current password"
+            required
+          />
+          <input
+            type="password"
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={newPassword}
+            onChange={(event) => setNewPassword(event.target.value)}
+            placeholder="New password"
+            minLength={8}
+            required
+          />
+          <button
+            type="submit"
+            className="rounded-lg bg-slate-900 px-4 py-2 text-white"
+            disabled={isChangingPassword}
+          >
+            {isChangingPassword ? 'Updating...' : 'Change password'}
+          </button>
+        </form>
+      </article>
+
+      <article className="space-y-3 rounded-xl border border-red-200 bg-red-50 p-6">
+        <h2 className="text-lg font-semibold text-red-700">Delete account</h2>
+        <p className="text-sm text-red-600">This action is permanent and cannot be undone.</p>
+        <button
+          className="rounded-lg border border-red-300 bg-white px-4 py-2 text-red-700"
+          onClick={onDeleteAccount}
+          disabled={isDeleting}
+        >
+          {isDeleting ? 'Deleting...' : 'Delete account'}
+        </button>
+      </article>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/pages/SettingsPage.tsx
+++ b/BlaBlaNote/apps/front/src/pages/SettingsPage.tsx
@@ -1,0 +1,116 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { profileApi } from '../api/profileApi';
+import { FormMessage } from '../components/profile/FormMessage';
+import { SettingsField } from '../components/profile/SettingsField';
+import { Loader } from '../components/ui/Loader';
+import { ApiError } from '../types/api.types';
+
+const THEME_STORAGE_KEY = 'blablanote-theme';
+
+export function SettingsPage() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [language, setLanguage] = useState('en');
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      setTheme(storedTheme);
+      document.documentElement.dataset.theme = storedTheme;
+    }
+
+    profileApi
+      .getMe()
+      .then((profile) => {
+        setLanguage(profile.language);
+        setTheme(profile.theme);
+        setNotificationsEnabled(profile.notificationsEnabled);
+        localStorage.setItem(THEME_STORAGE_KEY, profile.theme);
+        document.documentElement.dataset.theme = profile.theme;
+      })
+      .catch((error: ApiError) => {
+        setErrorMessage(error.message);
+      })
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  async function onSave(event: FormEvent) {
+    event.preventDefault();
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setIsSaving(true);
+
+    try {
+      const user = await profileApi.updateMe({
+        language,
+        theme,
+        notificationsEnabled,
+      });
+      localStorage.setItem(THEME_STORAGE_KEY, user.theme);
+      document.documentElement.dataset.theme = user.theme;
+      setSuccessMessage('Settings saved successfully.');
+    } catch (error) {
+      setErrorMessage((error as ApiError).message);
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (isLoading) {
+    return <Loader label="Loading settings..." />;
+  }
+
+  return (
+    <section className="mx-auto max-w-2xl space-y-6">
+      <h1 className="text-2xl font-bold text-slate-900">Settings</h1>
+      <FormMessage type="success" message={successMessage} />
+      <FormMessage type="error" message={errorMessage} />
+
+      <form className="space-y-4 rounded-xl border border-slate-200 bg-white p-6" onSubmit={onSave}>
+        <SettingsField label="Language">
+          <select
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={language}
+            onChange={(event) => setLanguage(event.target.value)}
+          >
+            <option value="en">English</option>
+            <option value="fr">Français</option>
+            <option value="ar">العربية</option>
+          </select>
+        </SettingsField>
+
+        <SettingsField label="Theme">
+          <select
+            className="rounded-lg border border-slate-300 px-3 py-2"
+            value={theme}
+            onChange={(event) => setTheme(event.target.value as 'light' | 'dark')}
+          >
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </SettingsField>
+
+        <label className="flex items-center justify-between rounded-lg border border-slate-200 px-3 py-2">
+          <span className="text-sm font-medium text-slate-700">Enable notifications</span>
+          <input
+            type="checkbox"
+            checked={notificationsEnabled}
+            onChange={(event) => setNotificationsEnabled(event.target.checked)}
+          />
+        </label>
+
+        <button
+          type="submit"
+          className="rounded-lg bg-slate-900 px-4 py-2 text-white"
+          disabled={isSaving}
+        >
+          {isSaving ? 'Saving...' : 'Save settings'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/BlaBlaNote/apps/front/src/router/AppRouter.tsx
+++ b/BlaBlaNote/apps/front/src/router/AppRouter.tsx
@@ -22,15 +22,8 @@ import { BlogListPage } from '../pages/BlogListPage';
 import { BlogDetailPage } from '../pages/BlogDetailPage';
 import { AdminBlogPage } from '../pages/admin/AdminBlogPage';
 import { AdminBlogCategoriesPage } from '../pages/admin/AdminBlogCategoriesPage';
-
-function PlaceholderPage({ title }: { title: string }) {
-  return (
-    <section>
-      <h1>{title}</h1>
-      <p>This area is coming soon.</p>
-    </section>
-  );
-}
+import { ProfilePage } from '../pages/ProfilePage';
+import { SettingsPage } from '../pages/SettingsPage';
 
 function renderAdminPage(path: string) {
   if (path === '/admin') {
@@ -149,7 +142,7 @@ function RoutedApp() {
     return (
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
-          <PlaceholderPage title="Profile" />
+          <ProfilePage />
         </AppLayout>
       </ProtectedRoute>
     );
@@ -159,7 +152,7 @@ function RoutedApp() {
     return (
       <ProtectedRoute redirectTo="/login">
         <AppLayout>
-          <PlaceholderPage title="Settings" />
+          <SettingsPage />
         </AppLayout>
       </ProtectedRoute>
     );

--- a/BlaBlaNote/apps/front/src/types/profile.types.ts
+++ b/BlaBlaNote/apps/front/src/types/profile.types.ts
@@ -1,0 +1,27 @@
+export interface ProfileUser {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: string;
+  isBlocked: boolean;
+  avatarUrl: string | null;
+  language: string;
+  theme: 'light' | 'dark';
+  notificationsEnabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateProfilePayload {
+  firstName?: string;
+  lastName?: string;
+  language?: string;
+  theme?: 'light' | 'dark';
+  notificationsEnabled?: boolean;
+}
+
+export interface ChangePasswordPayload {
+  currentPassword: string;
+  newPassword: string;
+}


### PR DESCRIPTION
### Motivation
- Add a full user profile and settings system so authenticated users can view/update their profile, change password, upload an avatar, delete their account, and persist language/theme/notification preferences.
- Store profile fields at the database level and expose a secure, validated API surface with Swagger documentation for frontend consumption.
- Provide a type-safe frontend API client and pages to manage profile and settings following the existing app architecture and auth flows.

### Description
- Updated Prisma `User` model to use `cuid()` id, convert `role` to `String` default `"USER"`, and added `isBlocked`, `avatarUrl`, `language`, `theme`, `notificationsEnabled` plus indexes, and added migration SQL in `apps/api/prisma/migrations/20260303000000_profile_settings/migration.sql`.
- Implemented a new JWT-protected `ProfileModule` with `ProfileController`, `ProfileService`, `ProfileStorageService`, and DTOs: `GET /me`, `PATCH /me`, `PATCH /me/password`, `DELETE /me`, and `POST /me/avatar` (multipart); responses never include `password` and all DTOs use `class-validator` and Swagger decorators.
- Added S3-compatible avatar upload support via a PUT upload workflow configurable through environment variables (`S3_UPLOAD_BASE_URL`, `S3_PUBLIC_BASE_URL`, `S3_UPLOAD_TOKEN`) and persisted `avatarUrl` on the user record.
- Integrated `ProfileModule` into `AppModule`, removed the legacy duplicate `DELETE /me` route from the old controller to avoid conflicts, and adjusted auth/JWT types to accept string roles.
- Frontend: added `profileApi.ts` (type-safe client), `ProfilePage` and `SettingsPage` React pages, small profile UI components, `profile`/`settings` routes wired into the router, and `profile.types.ts` for typings; theme persistence uses localStorage and document dataset.

### Testing
- Ran frontend production build with `NX_NO_CLOUD=true yarn nx run front:build` and it succeeded (build artifacts produced). ✅
- Ran frontend lint with `NX_NO_CLOUD=true yarn nx run front:lint` and it succeeded with a single warning only. ✅
- Ran API lint with `NX_NO_CLOUD=true yarn nx run api:lint` and it succeeded. ✅
- Attempted `NX_NO_CLOUD=true yarn nx run api:build` which failed in this environment due to Prisma client/engine generation constraints and blocked Prisma downloads (Prisma engine fetch returned 403), so compile verification for the API was not completed here. ⚠️
- Prisma tooling (`npx prisma format` / client generation) could not be executed because the Prisma engine download is blocked in this environment; apply the migration locally or in CI with DB access using `yarn prisma:migrate --name profile_settings`. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a245c49558832091b01cfa38a798aa)