### PR TITLE
docs: add full internal, API, architecture, and marketing documentation set

### DIFF
--- a/BlaBlaNote/API_REFERENCE.md
+++ b/BlaBlaNote/API_REFERENCE.md
@@ -1,0 +1,226 @@
+# API Reference
+
+Base URL: `http://localhost:3000`
+
+## Auth
+
+| Method | Path                    | Auth           | Role           | Description                                      |
+| ------ | ----------------------- | -------------- | -------------- | ------------------------------------------------ |
+| POST   | `/auth/register`        | No             | Public         | Register a new account                           |
+| POST   | `/auth/login`           | No             | Public         | Login and issue access + refresh tokens          |
+| POST   | `/auth/refresh`         | Refresh cookie | Public session | Rotate refresh token and return new access token |
+| POST   | `/auth/logout`          | Refresh cookie | Public session | Revoke current refresh session                   |
+| POST   | `/auth/forgot-password` | No             | Public         | Request password reset token                     |
+| POST   | `/auth/reset-password`  | No             | Public         | Reset password using token                       |
+
+## Notes
+
+| Method | Path                    | Auth   | Role   | Description                              |
+| ------ | ----------------------- | ------ | ------ | ---------------------------------------- |
+| GET    | `/notes`                | Bearer | User   | List notes with pagination/search/filter |
+| GET    | `/notes/:id`            | Bearer | User   | Get a single owned note                  |
+| POST   | `/notes`                | Bearer | User   | Create a note with text/audio metadata   |
+| POST   | `/notes/:id/retry`      | Bearer | User   | Retry failed transcription pipeline      |
+| PATCH  | `/notes/:id/project`    | Bearer | User   | Assign or clear project                  |
+| PUT    | `/notes/:id/tags`       | Bearer | User   | Replace note tags                        |
+| POST   | `/notes/:id/share`      | Bearer | User   | Share note by email/WhatsApp             |
+| POST   | `/notes/:id/share-link` | Bearer | User   | Create public share link                 |
+| GET    | `/notes/:id/shares`     | Bearer | User   | List share links for a note              |
+| GET    | `/public/notes/:token`  | No     | Public | Access shared note using token           |
+
+## Projects
+
+| Method | Path            | Auth   | Role | Description         |
+| ------ | --------------- | ------ | ---- | ------------------- |
+| GET    | `/projects`     | Bearer | User | List projects       |
+| POST   | `/projects`     | Bearer | User | Create project      |
+| PATCH  | `/projects/:id` | Bearer | User | Update project name |
+| DELETE | `/projects/:id` | Bearer | User | Delete project      |
+
+## Tags
+
+| Method | Path        | Auth   | Role | Description |
+| ------ | ----------- | ------ | ---- | ----------- |
+| GET    | `/tags`     | Bearer | User | List tags   |
+| POST   | `/tags`     | Bearer | User | Create tag  |
+| PATCH  | `/tags/:id` | Bearer | User | Update tag  |
+| DELETE | `/tags/:id` | Bearer | User | Delete tag  |
+
+## Profile
+
+| Method | Path           | Auth   | Role | Description                 |
+| ------ | -------------- | ------ | ---- | --------------------------- |
+| GET    | `/me`          | Bearer | User | Get current profile         |
+| PATCH  | `/me`          | Bearer | User | Update profile/preferences  |
+| PATCH  | `/me/password` | Bearer | User | Change password             |
+| POST   | `/me/avatar`   | Bearer | User | Upload avatar               |
+| DELETE | `/me`          | Bearer | User | Soft-delete current account |
+| GET    | `/me/export`   | Bearer | User | Export user data            |
+
+## Share
+
+| Method | Path          | Auth   | Role | Description         |
+| ------ | ------------- | ------ | ---- | ------------------- |
+| DELETE | `/shares/:id` | Bearer | User | Revoke a share link |
+
+## Admin
+
+| Method | Path                     | Auth   | Role  | Description              |
+| ------ | ------------------------ | ------ | ----- | ------------------------ |
+| GET    | `/admin/stats`           | Bearer | Admin | Get platform metrics     |
+| GET    | `/admin/jobs`            | Bearer | Admin | Get jobs/status overview |
+| GET    | `/admin/users`           | Bearer | Admin | List users with filters  |
+| PATCH  | `/admin/users/:id/block` | Bearer | Admin | Block or unblock a user  |
+
+## Blog
+
+| Method | Path                         | Auth   | Role   | Description               |
+| ------ | ---------------------------- | ------ | ------ | ------------------------- |
+| GET    | `/blog`                      | No     | Public | List published posts      |
+| GET    | `/blog/categories`           | No     | Public | List blog categories      |
+| GET    | `/blog/:slug`                | No     | Public | Get a published blog post |
+| POST   | `/admin/blog`                | Bearer | Admin  | Create blog post          |
+| PATCH  | `/admin/blog/:id`            | Bearer | Admin  | Update blog post          |
+| DELETE | `/admin/blog/:id`            | Bearer | Admin  | Delete blog post          |
+| POST   | `/admin/blog/categories`     | Bearer | Admin  | Create category           |
+| PATCH  | `/admin/blog/categories/:id` | Bearer | Admin  | Update category           |
+| DELETE | `/admin/blog/categories/:id` | Bearer | Admin  | Delete category           |
+
+## Representative Request/Response Examples
+
+### Register
+
+**Request**
+
+```http
+POST /auth/register
+Content-Type: application/json
+
+{
+  "firstName": "Jane",
+  "lastName": "Doe",
+  "email": "jane@company.com",
+  "password": "StrongPassword!123"
+}
+```
+
+**Response**
+
+```json
+{
+  "id": "clx123",
+  "email": "jane@company.com",
+  "role": "USER"
+}
+```
+
+### Login
+
+**Request**
+
+```http
+POST /auth/login
+Content-Type: application/json
+
+{
+  "email": "jane@company.com",
+  "password": "StrongPassword!123",
+  "rememberMe": true
+}
+```
+
+**Response**
+
+```json
+{
+  "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "user": {
+    "id": "clx123",
+    "email": "jane@company.com",
+    "role": "USER"
+  }
+}
+```
+
+### Create Note
+
+**Request**
+
+```http
+POST /notes
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "text": "Call summary from today",
+  "audioUrl": "https://cdn.example.com/audio/note-1.m4a",
+  "projectId": "proj_123"
+}
+```
+
+**Response**
+
+```json
+{
+  "id": "note_123",
+  "status": "UPLOADED",
+  "text": "Call summary from today",
+  "createdAt": "2026-01-10T10:00:00.000Z"
+}
+```
+
+### Create Share Link
+
+**Request**
+
+```http
+POST /notes/note_123/share-link
+Authorization: Bearer <access_token>
+Content-Type: application/json
+
+{
+  "expiresAt": "2026-02-10T10:00:00.000Z",
+  "allowSummary": true,
+  "allowTranscript": false
+}
+```
+
+**Response**
+
+```json
+{
+  "id": "share_123",
+  "url": "https://app.blablanote.com/public/notes/3V1Q...",
+  "expiresAt": "2026-02-10T10:00:00.000Z"
+}
+```
+
+### Admin Stats
+
+**Request**
+
+```http
+GET /admin/stats
+Authorization: Bearer <admin_access_token>
+```
+
+**Response**
+
+```json
+{
+  "users": 1240,
+  "notes": 38742,
+  "activeShareLinks": 901,
+  "failedPipelines": 17
+}
+```
+
+## Error Codes
+
+| HTTP Code | Meaning           | Typical Causes                                                 |
+| --------- | ----------------- | -------------------------------------------------------------- |
+| 400       | Bad Request       | Validation failure, malformed payload, business rule violation |
+| 401       | Unauthorized      | Missing/invalid access token, expired or invalid refresh token |
+| 403       | Forbidden         | Authenticated user lacks role/ownership permissions            |
+| 404       | Not Found         | Resource not found or not visible to requester                 |
+| 429       | Too Many Requests | Rate limit exceeded on protected/sensitive endpoints           |

--- a/BlaBlaNote/ARCHITECTURE_DIAGRAMS.md
+++ b/BlaBlaNote/ARCHITECTURE_DIAGRAMS.md
@@ -1,0 +1,169 @@
+# Architecture Diagrams
+
+## 1) System Context Diagram
+
+```mermaid
+graph LR
+  U[User] --> W[Web App\nReact + TypeScript]
+  W --> A[API\nNestJS]
+  A --> DB[(PostgreSQL)]
+  A --> WH[Whisper / Transcription Service]
+  A --> SM[Summarization Service]
+  A --> BR[Brevo Email]
+  A --> TW[Twilio WhatsApp]
+  A --> DC[Discord Webhook]
+  A --> S3[S3-Compatible Storage]
+```
+
+## 2) Backend Module Diagram (NestJS)
+
+```mermaid
+graph TD
+  APP[AppModule]
+  APP --> AUTH[AuthModule]
+  APP --> NOTES[NoteModule]
+  APP --> PROJECTS[ProjectModule]
+  APP --> TAGS[TagModule]
+  APP --> PROFILE[ProfileModule]
+  APP --> ADMIN[AdminModule]
+  APP --> BLOG[BlogModule]
+  APP --> PRISMA[PrismaModule]
+  APP --> WHISPER[WhisperModule]
+  APP --> DISCORD[DiscordModule]
+
+  NOTES --> PRISMA
+  NOTES --> WHISPER
+  NOTES --> DISCORD
+  NOTES --> TAGS
+  NOTES --> PROJECTS
+
+  AUTH --> PRISMA
+  PROFILE --> PRISMA
+  PROJECTS --> PRISMA
+  TAGS --> PRISMA
+  BLOG --> PRISMA
+  ADMIN --> PRISMA
+  WHISPER --> PRISMA
+```
+
+## 3) Sequence Diagram — Create Audio Note
+
+```mermaid
+sequenceDiagram
+  participant User as User
+  participant Web as Web App
+  participant API as API
+  participant Storage as S3 Storage
+  participant DB as PostgreSQL
+  participant Whisper as Whisper Service
+  participant Summarizer as Summarization Service
+  participant Discord as Discord Webhook
+
+  User->>Web: Create note with audio
+  Web->>API: POST /notes (metadata + audio ref)
+  API->>Storage: Upload audio object
+  Storage-->>API: audioUrl
+  API->>DB: Insert note status=UPLOADED
+  API->>DB: Update status=TRANSCRIBING
+  API->>Whisper: Transcribe audio
+  Whisper-->>API: transcriptText
+  API->>DB: Save transcript, status=SUMMARIZING
+  API->>Summarizer: Generate summary
+  Summarizer-->>API: summary
+  API->>DB: Save summary, status=READY
+  API->>Discord: Send notification event
+  API-->>Web: 201 Created + note payload
+  Web-->>User: Render note as processing/ready
+```
+
+## 4) Sequence Diagram — Refresh Token Rotation
+
+```mermaid
+sequenceDiagram
+  participant Web as Web App
+  participant API as API
+  participant DB as PostgreSQL
+
+  Web->>API: POST /auth/refresh (refresh cookie)
+  API->>DB: Lookup token hash + session
+  DB-->>API: token record
+  API->>API: Validate expiration/revocation/user state
+  API->>DB: Revoke old token + create replacement token
+  API-->>Web: Set-Cookie new refresh token + return accessToken
+  Web->>API: Retry original request with new access token
+  API-->>Web: 200 OK
+```
+
+## 5) ER Diagram (High-Level)
+
+```mermaid
+erDiagram
+  USER ||--o{ NOTE : owns
+  USER ||--o{ PROJECT : owns
+  USER ||--o{ TAG : owns
+  USER ||--o{ SHARE_LINK : creates
+  USER ||--o{ BLOG_POST : writes
+
+  PROJECT ||--o{ NOTE : contains
+  NOTE ||--o{ SHARE_LINK : exposes
+
+  NOTE ||--o{ NOTE_TAG : has
+  TAG ||--o{ NOTE_TAG : labels
+
+  BLOG_CATEGORY ||--o{ BLOG_POST : classifies
+
+  USER {
+    string id PK
+    string email
+    string role
+    string status
+  }
+
+  NOTE {
+    string id PK
+    string userId FK
+    string projectId FK
+    string status
+    string audioUrl
+  }
+
+  PROJECT {
+    string id PK
+    string userId FK
+    string name
+  }
+
+  TAG {
+    string id PK
+    string userId FK
+    string name
+    string slug
+  }
+
+  NOTE_TAG {
+    string noteId PK, FK
+    string tagId PK, FK
+  }
+
+  SHARE_LINK {
+    string id PK
+    string noteId FK
+    string createdByUserId FK
+    string tokenHash
+    datetime expiresAt
+  }
+
+  BLOG_POST {
+    string id PK
+    string authorId FK
+    string categoryId FK
+    string title
+    boolean published
+  }
+
+  BLOG_CATEGORY {
+    string id PK
+    string slug
+    string name
+  }
+```

--- a/BlaBlaNote/MARKETING_SITE.md
+++ b/BlaBlaNote/MARKETING_SITE.md
@@ -1,0 +1,249 @@
+# MARKETING SITE
+
+## 1) Brand Positioning
+
+### Tagline
+
+Turn every voice note into organized, shareable knowledge in minutes.
+
+### Key Value Propositions
+
+- Capture ideas by voice and get instant transcripts and summaries.
+- Keep notes structured with projects, tags, and fast search.
+- Share results securely with teams, clients, or stakeholders.
+
+### Target Audience Segments
+
+- Founders and operators capturing meetings and decisions
+- Consultants and agencies documenting client calls
+- Product and research teams summarizing interviews
+- Content creators planning episodes and scripts
+- Student and academic teams organizing study recordings
+- Sales teams logging call outcomes and follow-ups
+
+## 2) Landing Page Copy Sections
+
+### Hero Section
+
+- Headline: Voice notes in. Clear action items out.
+- Subheadline: BlaBlaNote transcribes, summarizes, and organizes your audio into searchable notes you can share instantly.
+- Primary CTA: Start free
+- Secondary CTA: Watch demo
+
+### Social Proof Section
+
+- Trusted by [Company Logo 1], [Company Logo 2], [Company Logo 3], [Company Logo 4]
+- “We reduced note-taking time by 70%.” — [Customer Name], [Role]
+- “Our team finally has one source of truth after every call.” — [Customer Name], [Role]
+
+### Problem Section
+
+Teams record meetings and voice memos all day.
+Raw audio is hard to search, hard to share, and easy to forget.
+Manual note-taking is slow and inconsistent.
+
+### Solution Section
+
+BlaBlaNote transforms voice input into structured outputs.
+You get transcript, summary, and organization in one flow.
+Share exactly what others need, without exposing everything.
+
+### How It Works
+
+1. Record or upload your voice note.
+2. BlaBlaNote transcribes the audio.
+3. AI generates summary and key context.
+4. Organize notes with projects and tags.
+5. Share by secure link, email, or WhatsApp.
+
+### Feature Grid
+
+- AI transcription pipeline
+- Smart summaries
+- Project-based organization
+- Custom tags
+- Full-text search
+- Pagination for large note libraries
+- Public share links with expiration
+- Scoped sharing permissions
+- Email sharing
+- WhatsApp sharing
+- Admin dashboard and moderation
+- English/French interface
+
+### Use Cases
+
+- Post-meeting executive summaries
+- Sales call recap and follow-up drafting
+- User interview synthesis
+- Personal knowledge capture on the go
+- Team daily standup logging
+- Podcast and content planning notes
+- Customer support call documentation
+- Coaching and consulting session records
+
+### Security & Privacy Section
+
+Your data stays under controlled access.
+JWT authentication with refresh rotation protects sessions.
+Share links are permission-scoped and time-limited.
+
+### Pricing Section
+
+#### Free
+
+- Limited notes per month
+- Basic transcription
+- Basic organization
+- Single user
+
+#### Pro
+
+- Higher note limits
+- Advanced summarization
+- Email and WhatsApp sharing
+- Priority processing
+
+#### Team
+
+- Multi-user workspace
+- Shared projects and governance
+- Admin controls
+- Usage visibility
+
+#### Enterprise
+
+- Custom limits and retention
+- Advanced security and controls
+- Priority support and onboarding
+- Custom integration options
+
+### FAQ
+
+1. How accurate is transcription?
+2. Which audio formats are supported?
+3. Can I organize notes by project?
+4. Can I tag notes for filtering?
+5. Is there a search feature?
+6. Can I share notes publicly?
+7. Can I control what shared viewers can see?
+8. Can I share by email and WhatsApp?
+9. Do you support team accounts?
+10. Is there an admin dashboard?
+11. Is my data encrypted in transit?
+12. Can I export my data?
+13. Do you support French?
+14. Is there a free plan?
+15. How do I upgrade or cancel?
+
+### Final CTA Section
+
+- Headline: Stop losing insights in raw audio.
+- Subheadline: Capture, summarize, organize, and share voice notes from one workspace.
+- Primary CTA: Start free today
+
+### Footer Links
+
+- Product
+  - Features
+  - Pricing
+  - Integrations
+  - Security
+- Resources
+  - Blog
+  - Documentation
+  - API Reference
+  - Changelog
+- Company
+  - About
+  - Contact
+  - Careers
+  - Partners
+- Legal
+  - Privacy Policy
+  - Terms of Service
+  - Data Processing Addendum
+
+## 3) SEO Essentials
+
+### Meta Title Suggestions
+
+1. BlaBlaNote | AI Voice Notes to Transcripts, Summaries, and Shareable Insights
+2. BlaBlaNote | Turn Voice Notes into Organized Team Knowledge
+3. AI Voice Note App for Teams | Transcribe, Summarize, Share | BlaBlaNote
+
+### Meta Description Suggestions
+
+1. Convert voice notes into searchable transcripts and summaries. Organize with projects and tags. Share securely by link, email, or WhatsApp.
+2. BlaBlaNote helps teams capture meeting insights faster with AI transcription, smart summaries, and secure sharing workflows.
+3. Record once, get structured notes instantly. BlaBlaNote powers voice-to-knowledge workflows for founders, teams, and agencies.
+
+### H1/H2 Structure
+
+- H1: Voice notes in. Clear action items out.
+- H2: Why teams use BlaBlaNote
+- H2: How BlaBlaNote works
+- H2: Features built for real workflows
+- H2: Use cases across teams
+- H2: Security and privacy
+- H2: Pricing plans
+- H2: Frequently asked questions
+- H2: Get started now
+
+### Keyword Cluster Suggestions
+
+- Core: ai voice notes, voice note transcription, voice note summary
+- Product-led: meeting transcription app, call summary software, audio notes organizer
+- Team workflows: team knowledge base from calls, client call documentation, interview note summarizer
+- Sharing: secure note sharing, share transcript link, whatsapp note sharing
+- Intent-based: best app for voice note summaries, convert voice memo to notes, searchable audio notes
+
+## 4) Blog Strategy
+
+### 20 Blog Post Title Ideas
+
+1. How to Turn Voice Notes into Actionable Meeting Summaries
+2. Voice Notes vs Manual Notes: A Practical Productivity Comparison
+3. Best Workflow for Organizing Team Audio Notes by Project
+4. How Sales Teams Can Save Hours with AI Call Summaries
+5. A Founder’s Guide to Capturing Decisions from Meetings
+6. How to Build a Repeatable User Interview Documentation Process
+7. Why Searchable Transcripts Improve Team Execution
+8. How to Share Meeting Notes Securely with Clients
+9. Reducing Context Loss in Remote Teams with Voice-First Documentation
+10. A Simple Framework for Tagging Notes at Scale
+11. How to Run Better Weekly Reviews with AI Summaries
+12. What to Include in a Client Call Recap Every Time
+13. From Raw Audio to Team Knowledge: End-to-End Process
+14. How to Keep Internal Notes Private While Sharing Externally
+15. Building a Personal Second Brain with Voice Notes
+16. The ROI of Faster Post-Meeting Documentation
+17. Common Mistakes Teams Make with Meeting Notes
+18. How to Use AI Summaries Without Losing Nuance
+19. Choosing the Right Voice Note App for Your Team
+20. Practical Data Privacy Checklist for Note-Taking SaaS Tools
+
+### 5 Pillar Pages
+
+1. AI Voice Note Documentation: Complete Guide
+2. Meeting Transcription and Summary Workflow Guide
+3. Team Knowledge Management from Audio Content
+4. Secure Note Sharing and Collaboration Guide
+5. Voice-to-Text Productivity Stack for Modern Teams
+
+### Internal Linking Strategy Summary
+
+- Link every feature-focused article to one relevant pillar page.
+- Link every use-case article to pricing and demo CTA pages.
+- Add contextual links between related workflows (sales, product, consulting).
+- Use comparison posts to route users to feature and security sections.
+- Keep a consistent CTA block at the end of each blog article.
+
+## 5) Tone & Style
+
+- Clear and modern SaaS voice
+- Short sentences
+- Direct, practical messaging
+- Low jargon
+- No hype statements
+- Benefit-led copy tied to workflow outcomes

--- a/BlaBlaNote/README.md
+++ b/BlaBlaNote/README.md
@@ -1,344 +1,158 @@
 # BlaBlaNote
 
-BlaBlaNote is a production-oriented AI voice-notes platform built in an Nx monorepo with NestJS + React. It enables users to upload voice notes, generate transcriptions and summaries with AI, organize notes by projects/tags, and share content through private/public channels.
+BlaBlaNote is a full-stack SaaS platform that converts voice notes into searchable, structured knowledge with AI-powered transcription, summarization, organization, and sharing.
 
----
+## Feature List
 
-## Features Overview
-
-### Core Product Features
-- Voice note upload (audio file intake and processing)
-- AI transcription (OpenAI Whisper)
-- AI summarization + translation support
-- Notes CRUD and lifecycle tracking (`UPLOADED`, `TRANSCRIBING`, `SUMMARIZING`, `READY`, `FAILED`)
-- Projects for note organization
-- Tag system per user
-- Search and filters (text, date range, tags, project)
-
-### Sharing Features
-- Share by email (Brevo)
-- Share by WhatsApp (Twilio)
-- Public secure share links with token + expiration + permission flags
-
-### Platform Features
-- JWT authentication (access token + rotating refresh token)
-- User self-service endpoints (profile export, account deletion)
-- Admin dashboard APIs (stats, users, jobs monitoring)
-- Blog module (public posts + admin management)
-- Discord webhook notifications for operational/user actions
-- Swagger API documentation
-
----
+- Email/password authentication with JWT access tokens and refresh token rotation
+- User registration, login, logout, forgot password, reset password
+- Voice note creation with optional audio upload
+- Note lifecycle tracking: uploaded, transcribing, summarizing, ready, failed
+- AI transcription pipeline
+- AI summarization and translation fields per note
+- Notes listing with pagination, filtering, and search
+- Project management for note grouping
+- Tag management and many-to-many note tagging
+- Public share links with scoped permissions and expiration
+- Share by email and WhatsApp
+- Profile and account settings management
+- Avatar upload through S3-compatible storage gateway
+- Admin dashboard stats and background job visibility
+- Admin user management and block/unblock workflow
+- Blog and blog categories with admin publishing workflows
+- Discord webhook notifications
+- Internationalization support for English and French in frontend
+- API documentation through Swagger
+- Backend unit and e2e tests, frontend unit and e2e tests
 
 ## Tech Stack
 
-| Layer | Technology |
-|---|---|
-| Monorepo | Nx |
-| Backend | NestJS (TypeScript) |
-| Frontend | React + Vite + TypeScript + Ant Design |
-| Database | PostgreSQL |
-| ORM | Prisma |
-| Auth | JWT (access) + Refresh token rotation |
-| AI | OpenAI Whisper + Chat Completions |
-| Messaging | Brevo (email), Twilio (WhatsApp) |
-| Observability | Request logging middleware + Discord webhook |
-| API Docs | Swagger (`/api/docs`) |
-| Package Manager | Yarn 1.x |
+- Monorepo: Nx
+- Package manager: Yarn 1
+- Backend: NestJS, Prisma, PostgreSQL
+- Frontend: React, TypeScript, Vite, Ant Design
+- Authentication: JWT + refresh token rotation with secure HTTP-only cookie
+- Validation: class-validator, class-transformer
+- API docs: Swagger (`@nestjs/swagger`)
+- Testing: Jest, Vitest, Playwright
+- Integrations: OpenAI Whisper API, Brevo, Twilio WhatsApp, Discord webhook, S3-compatible storage
 
----
-
-## Architecture Overview
-
-BlaBlaNote follows a modular, layered approach aligned with clean architecture principles:
-
-- **Presentation layer**: NestJS controllers + DTO validation
-- **Application layer**: services encapsulating business flows (auth, notes, admin, blog, tags, projects)
-- **Infrastructure layer**: Prisma, external providers (OpenAI, Brevo, Twilio, Discord)
-- **Frontend layer**: modular React app consuming typed API clients
-
-The workspace contains two main applications:
-- `apps/api`: backend REST API
-- `apps/front`: frontend SPA
-
----
-
-## Folder Structure
+## Monorepo Structure
 
 ```text
-BlaBlaNote/
-├─ apps/
-│  ├─ api/
-│  │  ├─ prisma/
-│  │  │  ├─ schema.prisma
-│  │  │  └─ seed.ts
-│  │  └─ src/app/
-│  │     ├─ auth/
-│  │     ├─ note/
-│  │     ├─ whisper/
-│  │     ├─ admin/
-│  │     ├─ blog/
-│  │     ├─ project/
-│  │     ├─ tag/
-│  │     ├─ user/
-│  │     ├─ discord/
-│  │     └─ prisma/
-│  ├─ front/
-│  │  └─ src/
-│  │     ├─ api/
-│  │     ├─ modules/
-│  │     ├─ pages/
-│  │     ├─ layouts/
-│  │     ├─ router/
-│  │     └─ types/
-│  ├─ api-e2e/
-│  └─ front-e2e/
-├─ docs/
-├─ docker-compose.yml
-├─ package.json
-└─ nx.json
+apps/
+  api/          NestJS API + Prisma schema + seed
+  api-e2e/      Backend end-to-end tests
+  front/        React frontend (Vite)
+  front-e2e/    Frontend Playwright tests
 ```
 
----
+## Setup
 
-## Environment Variables
+### Prerequisites
 
-Create a `.env` file at repository root.
-
-| Variable | Required | Example | Description |
-|---|---|---|---|
-| `DATABASE_URL` | Yes | `postgresql://user:pass@localhost:5432/blablanote?schema=public` | Prisma connection string |
-| `POSTGRES_USER` | Yes (docker) | `postgres` | PostgreSQL username for `docker-compose` |
-| `POSTGRES_PASSWORD` | Yes (docker) | `postgres` | PostgreSQL password for `docker-compose` |
-| `POSTGRES_DB` | Yes (docker) | `blablanote` | PostgreSQL database name |
-| `PORT` | No | `3001` | Backend API port |
-| `FRONTEND_URL` | No | `http://localhost:4200` | CORS allowed frontend origin |
-| `APP_URL` | No | `http://localhost:3001` | Base URL used in generated public share links |
-| `NODE_ENV` | No | `development` / `production` | Affects cookie security settings |
-| `JWT_SECRET` | Yes (prod) | `super-secret` | JWT signing secret |
-| `JWT_ACCESS_EXPIRES_IN` | No | `15m` | Access token expiration |
-| `JWT_REFRESH_REMEMBER_ME_DAYS` | No | `30` | Refresh token TTL (remember me) |
-| `JWT_REFRESH_SESSION_HOURS` | No | `24` | Refresh token TTL (session mode) |
-| `RESET_PASSWORD_TOKEN_MINUTES` | No | `20` | Password reset token validity |
-| `BCRYPT_ROUNDS` | No | `10` | Password hashing rounds |
-| `ADMIN_EMAIL` | Optional | `admin@blablanote.com` | Seed admin email |
-| `ADMIN_PASSWORD` | Optional | `StrongPass123!` | Seed admin password |
-| `OPENAI_API_KEY` | Yes (AI features) | `sk-...` | Used for Whisper + summarization |
-| `BREVO_API_KEY` | Optional | `xkeysib-...` | Email sharing provider key |
-| `TWILIO_ACCOUNT_SID` | Optional | `AC...` | Twilio account SID |
-| `TWILIO_AUTH_TOKEN` | Optional | `...` | Twilio auth token |
-| `TWILIO_WHATSAPP_NUMBER` | Optional | `whatsapp:+14155238886` | Sender number for WhatsApp share |
-| `DISCORD_WEBHOOK_URL` | Optional | `https://discord.com/api/webhooks/...` | Notifications for actions/events |
-| `VITE_API_BASE_URL` | Yes (frontend) | `http://localhost:3001` | Frontend API base URL |
-
----
-
-## Installation
-
-### 1) Prerequisites
 - Node.js 20+
-- Yarn `1.22.x`
+- Yarn 1.22+
 - PostgreSQL 14+
-- (Optional) Docker & Docker Compose
 
-### 2) Install dependencies
+### Install
 
 ```bash
 yarn install
 ```
 
-### 3) Start PostgreSQL (optional via Docker)
+## Environment Variables
 
-```bash
-docker compose up -d db
-```
+| Variable                       | Required    | Scope            | Description                                   | Example                                                 |
+| ------------------------------ | ----------- | ---------------- | --------------------------------------------- | ------------------------------------------------------- |
+| `DATABASE_URL`                 | Yes         | API/Prisma       | Primary PostgreSQL connection string          | `postgresql://user:pass@localhost:5432/blablanote`      |
+| `DATABASE_URL_TEST`            | Recommended | API E2E          | Dedicated test database URL                   | `postgresql://user:pass@localhost:5432/blablanote_test` |
+| `PORT`                         | No          | API              | API port                                      | `3000`                                                  |
+| `HOST`                         | No          | API E2E          | Host used by API e2e setup                    | `127.0.0.1`                                             |
+| `FRONTEND_URL`                 | Yes         | API/Auth/CORS    | Frontend origin for CORS and links            | `http://localhost:4300`                                 |
+| `APP_URL`                      | Yes         | API/Share        | Public app URL used in share links            | `http://localhost:4300`                                 |
+| `JWT_SECRET`                   | Yes         | API/Auth/Whisper | JWT signature secret                          | `change_me`                                             |
+| `JWT_ACCESS_EXPIRES_IN`        | No          | API/Auth         | Access token TTL                              | `15m`                                                   |
+| `JWT_REFRESH_REMEMBER_ME_DAYS` | No          | API/Auth         | Refresh token TTL when remember-me is enabled | `30`                                                    |
+| `JWT_REFRESH_SESSION_HOURS`    | No          | API/Auth         | Refresh token TTL for session mode            | `24`                                                    |
+| `RESET_PASSWORD_TOKEN_MINUTES` | No          | API/Auth         | Password reset token validity window          | `20`                                                    |
+| `OPENAI_API_KEY`               | Yes         | API/Whisper      | OpenAI API key for transcription              | `sk-...`                                                |
+| `BREVO_API_KEY`                | Optional    | API/Share        | Brevo transactional email API key             | `xkeysib-...`                                           |
+| `TWILIO_ACCOUNT_SID`           | Optional    | API/Share        | Twilio account SID                            | `AC...`                                                 |
+| `TWILIO_AUTH_TOKEN`            | Optional    | API/Share        | Twilio auth token                             | `...`                                                   |
+| `TWILIO_WHATSAPP_NUMBER`       | Optional    | API/Share        | Twilio sender number for WhatsApp             | `whatsapp:+14155238886`                                 |
+| `DISCORD_WEBHOOK_URL`          | Optional    | API/Discord      | Discord webhook endpoint                      | `https://discord.com/api/webhooks/...`                  |
+| `S3_UPLOAD_BASE_URL`           | Optional    | API/Profile      | Upload endpoint for S3-compatible gateway     | `https://storage.example.com/upload`                    |
+| `S3_PUBLIC_BASE_URL`           | Optional    | API/Profile      | Public base URL for uploaded files            | `https://cdn.example.com`                               |
+| `S3_UPLOAD_TOKEN`              | Optional    | API/Profile      | Bearer token used for upload gateway auth     | `token_value`                                           |
+| `SEED_ADMIN_EMAIL`             | Optional    | Prisma seed      | Admin bootstrap email                         | `admin@blablanote.com`                                  |
+| `SEED_ADMIN_PASSWORD`          | Optional    | Prisma seed      | Admin bootstrap password                      | `ChangeThisPassword!123`                                |
+| `VITE_API_BASE_URL`            | Yes         | Frontend         | API base URL used by frontend HTTP client     | `http://localhost:3000`                                 |
+| `BASE_URL`                     | No          | Frontend E2E     | Frontend URL for Playwright tests             | `http://localhost:4300`                                 |
+| `CI`                           | No          | Frontend E2E     | Playwright CI mode toggle                     | `true`                                                  |
+| `NODE_ENV`                     | No          | API              | Runtime environment mode                      | `development`                                           |
 
-### 4) Generate Prisma client
+## Run Locally
 
-```bash
-yarn prisma:generate
-```
-
-### 5) Run database migrations
-
-```bash
-yarn prisma:migrate
-```
-
-### 6) (Optional) Seed admin user
-
-```bash
-npx prisma db seed
-```
-
----
-
-## Prisma Migration Commands
-
-```bash
-# Sync schema to root prisma folder + generate client
-yarn prisma:generate
-
-# Create/apply dev migration
-yarn prisma:migrate
-
-# Deploy migrations in production
-npx prisma migrate deploy
-
-# Open Prisma Studio
-npx prisma studio
-```
-
----
-
-## Running Locally
-
-### Backend (API)
+### API
 
 ```bash
 yarn nx serve api
 ```
 
-API default URL: `http://localhost:3001`
-
-### Frontend (Web App)
+### Frontend
 
 ```bash
 yarn nx serve front
 ```
 
-Frontend default URL (Nx/Vite): typically `http://localhost:4200`
-
-### Run both (two terminals)
-- Terminal A: `yarn nx serve api`
-- Terminal B: `yarn nx serve front`
-
----
-
-## Running in Production
-
-### 1) Build all applications
+## Prisma Commands
 
 ```bash
-yarn build
+yarn prisma:generate
+yarn prisma:migrate
+yarn prisma:migrate:test
+yarn prisma db seed
 ```
 
-### 2) Apply migrations
+## Swagger
 
-```bash
-npx prisma migrate deploy
-```
-
-### 3) Start API in production mode
-
-```bash
-yarn nx serve api --configuration=production
-```
-
-> For hardened production deployment, run built output with a process manager (PM2/systemd), configure HTTPS/TLS at reverse proxy level, and use managed PostgreSQL + secret manager.
-
----
-
-## Swagger Documentation
-
-When API is running:
-
-- Swagger UI: `http://localhost:3001/api/docs`
-
-Use Swagger Authorize button with:
+When API is running locally, open:
 
 ```text
-Bearer <access_token>
+http://localhost:3000/api
 ```
 
----
+## Auth Flow
 
-## API Authentication (Access + Refresh)
+1. `POST /auth/login` returns an access token and sets an HTTP-only refresh cookie.
+2. Access token is sent as `Authorization: Bearer <token>` for protected endpoints.
+3. On expiry, client calls `POST /auth/refresh` with refresh cookie.
+4. Server validates refresh token hash, session state, and expiration.
+5. Server rotates refresh token, revokes old token, sets new cookie, returns new access token.
+6. Client retries original request with new access token.
 
-### Login
-1. `POST /auth/login` with email/password (+ optional `rememberMe`)
-2. API returns `access_token` in JSON
-3. API sets refresh token as **HttpOnly cookie** (`/auth` scoped)
+## Storage (S3-Compatible)
 
-### Authenticated requests
-- Frontend sends `Authorization: Bearer <access_token>`
-- On `401`, frontend calls `POST /auth/refresh` automatically
-- If refresh succeeds, original request is retried
+- Audio and avatar binary payloads are stored via an S3-compatible upload gateway.
+- API uses `S3_UPLOAD_BASE_URL` + `S3_UPLOAD_TOKEN` for uploads.
+- Public URLs are resolved using `S3_PUBLIC_BASE_URL`.
 
-### Logout
-- `POST /auth/logout` revokes refresh token
-- Refresh cookie is cleared
-
----
-
-## Testing Instructions
+## Testing Commands
 
 ```bash
-# Unit/integration tests (if configured)
-yarn nx test api
-yarn nx test front
-
-# E2E projects
-yarn nx test api-e2e
-yarn nx test front-e2e
-
-# Lint
-yarn nx lint api
-yarn nx lint front
+yarn test:api
+yarn test:api:e2e
+yarn test:web
+yarn test:web:e2e
+yarn test:all
 ```
 
-If some targets are not defined yet in your local Nx setup, run:
+## Troubleshooting
 
-```bash
-yarn nx show project <project-name>
-```
-
----
-
-## Common Errors & Troubleshooting
-
-### 1) `P1001: Can't reach database server`
-- Ensure PostgreSQL is running
-- Verify `DATABASE_URL`
-- If Dockerized DB: `docker compose ps`
-
-### 2) `Missing Discord Webhook URL`
-- Set `DISCORD_WEBHOOK_URL`
-- Or disable webhook calls in flows where not required
-
-### 3) `401 Unauthorized` loops
-- Ensure frontend sends cookies (`withCredentials: true`)
-- Verify `FRONTEND_URL` and CORS config
-- Check `JWT_SECRET` consistency across environments
-
-### 4) Whisper/OpenAI errors
-- Validate `OPENAI_API_KEY`
-- Ensure uploaded extension is supported (`.mp3`, `.wav`, `.m4a`, etc.)
-- Check outbound network access to OpenAI API
-
-### 5) Sharing failures (Email/WhatsApp)
-- Validate Brevo/Twilio credentials
-- Confirm sender identities are approved in providers
-
-### 6) Public links open wrong host
-- Set `APP_URL` to correct public backend URL
-
----
-
-## Future Improvements
-
-- Async queue (BullMQ/RabbitMQ/SQS) for transcription pipeline
-- S3-compatible object storage adapter for uploaded audio + attachments
-- Replace in-memory access token handling with secure persistence strategy
-- Centralized observability stack (OpenTelemetry + Prometheus + Grafana)
-- Rate limiting and abuse protection hardening by route category
-- API versioning policy (`/v1`)
-- Multi-language summarization options per user preferences
-- CI quality gates (coverage thresholds, security scans, migration checks)
-- Blue/green or canary deployment strategy
-
----
-
-## License
-
-MIT
+- `PrismaClientInitializationError`: verify `DATABASE_URL`, DB availability, and migration state.
+- `401 Unauthorized` after refresh: clear browser cookies and re-authenticate to reset token chain.
+- CORS issues in local development: align `FRONTEND_URL`, `VITE_API_BASE_URL`, and API `PORT`.
+- Transcription failures: validate `OPENAI_API_KEY`, request limits, and network egress.
+- WhatsApp/email share not delivered: verify Brevo/Twilio credentials and sender configuration.
+- Avatar upload failures: verify storage gateway URL, token, and returned public URL mapping.

--- a/BlaBlaNote/TECHNICAL_SPECIFICATION.md
+++ b/BlaBlaNote/TECHNICAL_SPECIFICATION.md
@@ -1,322 +1,162 @@
-# TECHNICAL_SPECIFICATION.md
+# Technical Specification
 
-## 1. Document Purpose
+## Architecture Overview
 
-This document defines the developer-focused technical design of BlaBlaNote, including architecture, data model, API segmentation, security model, AI processing lifecycle, and production operations.
+BlaBlaNote is an Nx monorepo with a NestJS backend (`apps/api`) and a React frontend (`apps/front`).
+
+### Backend Modules and Responsibilities
 
----
+- `AuthModule`: registration, login, refresh rotation, logout, forgot/reset password
+- `UserModule`: user CRUD, role management, terms acceptance, data export
+- `ProfileModule`: self-service profile updates, password update, avatar upload
+- `NoteModule`: note CRUD, search/filter, project assignment, tagging, sharing, public read
+- `WhisperModule`: transcription integration and note processing state updates
+- `ProjectModule`: project CRUD and ownership constraints
+- `TagModule`: tag CRUD with user-level uniqueness by slug
+- `ShareModule` (within note domain): share link lifecycle and revocation
+- `AdminModule`: platform stats, jobs overview, user moderation
+- `BlogModule`: public blog retrieval, admin publishing and category management
+- `DiscordModule`: outbound webhook notifications for domain events
+- `PrismaModule`: shared data access layer and connection lifecycle
 
-## 2. System Architecture
-
-## 2.1 High-Level Components
-
-1. **Frontend (React + Vite)**
-   - SPA for end users and admins
-   - Access token bearer authentication
-   - Automatic token refresh via HTTP-only cookie
-
-2. **Backend API (NestJS)**
-   - REST API with modular domain boundaries (auth, notes, projects, tags, admin, blog, user)
-   - DTO validation and role-based route protection
-   - Swagger auto-documentation
-
-3. **Database (PostgreSQL + Prisma)**
-   - Relational persistence for users, notes, projects, tags, blog, token/session metadata
-
-4. **AI Services**
-   - OpenAI Whisper for transcription
-   - OpenAI Chat Completions for summarization and translation
-
-5. **External Integrations**
-   - Brevo transactional email
-   - Twilio WhatsApp messaging
-   - Discord webhook for activity notifications
-
-6. **Storage Layer**
-   - Current implementation: local disk uploads (`./uploads`)
-   - Target architecture: pluggable S3-compatible object storage adapter
-
----
-
-## 2.2 Runtime Topology
-
-- `front` app runs separately from `api`
-- `api` connects to PostgreSQL via `DATABASE_URL`
-- `api` calls external APIs over HTTPS (OpenAI, Twilio, Brevo, Discord)
-- CORS is configured to allow the frontend origin
-
----
-
-## 3. Database Schema (Prisma)
-
-## 3.1 Core Domain Entities
-
-- **User**: identity, role, status, billing metadata, lifecycle timestamps
-- **Note**: core note content + AI outputs + processing state
-- **Project**: user-owned grouping of notes
-- **Tag** and **NoteTag**: user-scoped tagging and note-tag many-to-many linkage
-- **ShareLink**: hashed public token links with expiry and field-level access flags
-
-## 3.2 Security/Auth Entities
-
-- **RefreshToken**: token rotation graph (replacement chain), per-session metadata, revocation tracking
-- **PasswordResetToken**: one-time reset token with expiry + usage timestamp
-
-## 3.3 Content/Admin Entities
-
-- **BlogPost** and **BlogCategory**: public content with admin-managed publishing workflow
-
-## 3.4 Key Relational Rules
-
-- User -> Notes/Projects/Tags/BlogPosts cascade on delete
-- Note -> ShareLinks cascade on delete
-- Note <-> Tag via NoteTag composite PK (`noteId`, `tagId`)
-- Project deletion sets related Note.projectId to null
-- Unique constraints:
-  - `User.email`
-  - `Tag(userId, slug)`
-  - `RefreshToken.tokenHash`
-  - `PasswordResetToken.tokenHash`
-  - `BlogPost.slug`, `BlogCategory.slug`
-
----
-
-## 4. API Structure
-
-## 4.1 Public Endpoints
-
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/refresh`
-- `POST /auth/logout`
-- `POST /auth/forgot-password`
-- `POST /auth/reset-password`
-- `GET /public/notes/:token`
-- `GET /blog`
-- `GET /blog/:slug`
-- `GET /blog/categories`
-
-## 4.2 Protected Endpoints (Authenticated User)
-
-- Notes: list/get/create/retry/assign project/replace tags/share/create share-link/history
-- Shares: revoke share-link
-- Projects: CRUD
-- Tags: CRUD
-- Whisper: upload/transcribe audio
-- Me: data export + account deletion
-- User profile/self and own resource operations
-
-## 4.3 Admin Endpoints (Role = ADMIN)
-
-- `GET /admin/stats`
-- `GET /admin/jobs`
-- `GET /admin/users`
-- `PATCH /admin/users/:id/block`
-- Blog administration endpoints under `/admin/blog...`
-- Admin-level user creation / role updates
-
-## 4.4 API Documentation
-
-- Swagger UI: `/api/docs`
-- Bearer auth configured in Swagger definition
-
----
-
-## 5. Authentication & Session Flow (Access + Refresh)
-
-## 5.1 Token Model
-
-- **Access token**: short-lived JWT used in Authorization header
-- **Refresh token**: long-lived opaque token stored as HttpOnly cookie
-- Refresh tokens are persisted hashed and rotated per refresh event
-
-## 5.2 Login Sequence
-
-1. User submits credentials
-2. Credentials validated (bcrypt compare)
-3. Access token issued
-4. Refresh token issued + stored (hash, sessionId, metadata)
-5. Refresh token returned as secure cookie
-
-## 5.3 Refresh Sequence
-
-1. Frontend receives `401` on API request
-2. Calls `POST /auth/refresh` with refresh cookie automatically attached
-3. Backend validates refresh token hash + expiration + revocation status
-4. Backend rotates token (old revoked/replaced, new persisted)
-5. Backend returns new access token + new refresh cookie
-
-## 5.4 Logout Sequence
-
-1. Frontend calls `POST /auth/logout`
-2. Backend revokes current refresh token
-3. Refresh cookie cleared
-4. Frontend clears access token and local user snapshot
-
----
-
-## 6. Transcription Pipeline States
-
-`Note.status` lifecycle:
-
-1. **UPLOADED**
-   - Audio path known, processing pending
-2. **TRANSCRIBING**
-   - Whisper request in progress
-3. **SUMMARIZING**
-   - Transcript generated; summary/translation in progress
-4. **READY**
-   - Transcript + summary (and optional translation) persisted
-5. **FAILED**
-   - Any error captured in `errorMessage`
-
-Retry logic:
-- If audio is available, pipeline restarts from transcription
-- If transcript exists without audio, summarization can be retried directly
-
----
-
-## 7. Error Handling Strategy
-
-- NestJS HTTP exceptions for expected domain errors (e.g., not found, validation)
-- Prisma and external API errors transformed into controlled failure states where relevant
-- Pipeline failures persist recoverable status and error message in `Note`
-- API consumers receive structured HTTP error payloads
-- Frontend normalizes Axios errors into typed `ApiError`
-
----
-
-## 8. Security Considerations
-
-- Passwords hashed with bcrypt (`BCRYPT_ROUNDS` configurable)
-- JWT secret must be strong and environment-specific
-- Refresh token is cookie-based and not exposed to JavaScript
-- Token hashes stored instead of raw refresh token values
-- Role guard enforces ADMIN-only routes
-- DTO validation pipe with whitelist/forbidNonWhitelisted enabled
-- Public share access uses random token + SHA-256 hash lookup
-- Share links are time-bounded and permission-scoped (`allowSummary`, `allowTranscript`)
-- CORS restricted to configured frontend origin
-
-Recommended hardening:
-- Add rate limits on auth/share endpoints
-- Add CSRF strategy for cookie-based refresh endpoint
-- Centralized secret manager and key rotation policy
-- Endpoint-level audit trail persisted to DB/SIEM
-
----
-
-## 9. Data Flow Diagrams (Textual)
-
-## 9.1 Note Upload + AI Processing
-
-`Frontend -> POST /whisper/transcribe -> API stores file locally -> Note(UPLOADED) -> Note(TRANSCRIBING) -> OpenAI Whisper -> Note(SUMMARIZING) -> OpenAI Chat -> Note(READY) -> Frontend polls/queries note`
-
-## 9.2 Authenticated API Call with Auto-Refresh
-
-`Frontend request (Bearer access) -> API validates JWT -> (if expired) 401 -> Frontend POST /auth/refresh (cookie) -> API rotates refresh token -> new access token -> retry original request`
-
-## 9.3 Public Share Link Read
-
-`Recipient opens /public/notes/:token -> API hashes token -> ShareLink lookup by hash + expiresAt -> if valid, return only permitted fields`
-
----
-
-## 10. Scalability Considerations
-
-- Current AI processing is synchronous in request path; move to job queue for scale
-- Horizontal scaling requires stateless API nodes + shared DB + shared object storage
-- Introduce worker pool for transcription/summarization tasks
-- Use Redis for queue coordination, distributed locks, and short-term caching
-- Consider read replicas for analytics-heavy admin views
-
----
-
-## 11. Performance Optimization Strategy
-
-- DB indexes already present on common query filters (status, createdAt, foreign keys)
-- Pagination on list endpoints (`page`, `pageSize`) reduces payload size
-- Use selective field projection in admin/jobs endpoints
-- Suggested improvements:
-  - Query performance observability + slow query logging
-  - Cache blog public list/detail and static metadata
-  - Offload heavy AI operations to async workers
-  - Use CDN for frontend/static assets
-
----
-
-## 12. Logging & Monitoring Strategy
-
-Current:
-- Request logging middleware in backend
-- Discord webhook notifications for key user actions/events
-
-Recommended production stack:
-- Structured JSON logs (requestId, userId, route, latency)
-- Centralized log sink (ELK/OpenSearch/Datadog)
-- Metrics: request latency, error rates, queue depth, AI provider latency/cost
-- Alerting: high failure rate, auth anomalies, webhook failures, DB connection pool pressure
-
----
-
-## 13. Deployment Architecture
-
-Minimal production architecture:
-- Reverse proxy (Nginx/Traefik)
-- Frontend static hosting (CDN/object storage)
-- API service instances (containerized)
-- Managed PostgreSQL
-- Object storage (S3-compatible)
-- Secret manager for credentials
-
-CI/CD expectations:
-- Lint/test/build/migrate checks
-- Immutable image builds
-- Environment-specific config injection
-- Controlled migration deployment step before app rollout
-
----
-
-## 14. Backup & Recovery Strategy
-
-Database:
-- Daily full backups + WAL/incremental backups
-- Point-in-time recovery (PITR) for managed PostgreSQL
-- Backup retention by compliance policy (e.g., 30/90 days)
-
-Object storage:
-- Versioning + lifecycle retention policies
-- Cross-region replication for DR (if business-critical)
-
-Recovery drills:
-- Scheduled restore simulation in staging
-- RPO/RTO targets documented and validated
-
----
-
-## 15. GDPR Compliance Handling
-
-Key controls:
-- User data export endpoint (`/me/export`)
-- User deletion endpoint (`DELETE /me`) for account erasure workflow
-- Token/session revocation capabilities
-- Purpose limitation by domain modules
-- Public share links are explicit, scoped, and time-limited
-
-Recommendations for full compliance posture:
-- Add consent ledger and legal basis mapping
-- Encrypt sensitive data at rest + in transit
-- Data retention schedules and automated purging for old artifacts
-- DPA with all subprocessors (OpenAI, Twilio, Brevo, hosting provider)
-- Documented incident response and breach notification procedure
-
----
-
-## 16. Open Technical Roadmap
-
-- Queue-based AI orchestration
-- Idempotent job processing + dead-letter handling
-- True S3 upload flow (pre-signed URLs, lifecycle policies)
-- Multi-tenant readiness (logical partitioning)
-- Fine-grained admin RBAC permissions
-- Dedicated audit log table and immutable activity records
+### Frontend Responsibilities
+
+- Auth and session state management
+- Note creation, listing, filtering, and detail pages
+- Project and tag management interfaces
+- Profile/settings interface with language/theme preferences
+- Public shared note page
+- Admin dashboard and blog management views
+- i18n content rendering (`en`, `fr`)
+
+## Database Schema Overview
+
+### Core Models
+
+- `User`: identity, role, account status, preferences, billing metadata
+- `Note`: owned content item with AI pipeline status and optional audio URL
+- `Project`: user-owned grouping entity linked one-to-many with notes
+- `Tag`: user-owned label, unique by `(userId, slug)`
+- `NoteTag`: many-to-many join between notes and tags
+- `ShareLink`: token-hashed public link with scoped permissions and expiration
+- `RefreshToken`: hashed refresh token chain for rotation and session controls
+- `PasswordResetToken`: one-time token hashes with expiration and used timestamp
+- `BlogPost`: authored content with optional category link
+- `BlogCategory`: taxonomy for blog posts
+
+### Key Relations
+
+- `User 1:N Note`, `User 1:N Project`, `User 1:N Tag`
+- `Note N:M Tag` through `NoteTag`
+- `Note 1:N ShareLink`
+- `User 1:N RefreshToken`
+- `User 1:N PasswordResetToken`
+- `User 1:N BlogPost`
+- `BlogCategory 1:N BlogPost`
+
+## API Design
+
+### Public Endpoints
+
+- Health check
+- Blog listing/category/detail
+- Public note access by share token
+- Auth register/login/refresh/logout/forgot/reset
+
+### Protected Endpoints
+
+- Notes, Projects, Tags
+- Profile (`/me` routes)
+- Share creation/list/revoke
+- User self actions (accept terms, export)
+
+### Admin Endpoints
+
+- `/admin/stats`, `/admin/jobs`
+- `/admin/users` listing and moderation
+- `/admin/blog` post/category create/update/delete
+
+### API Conventions
+
+- JSON request/response payloads
+- Bearer access token for protected routes
+- HTTP-only cookie for refresh token
+- DTO-based validation with class-validator
+- Paginated list responses on collection endpoints
+
+## Transcription Pipeline States and Lifecycle
+
+`Note.status` transitions:
+
+1. `UPLOADED`: note created and persisted
+2. `TRANSCRIBING`: audio/transcript generation in progress
+3. `SUMMARIZING`: summarization and optional translation in progress
+4. `READY`: transcript/summary persisted and visible to user
+5. `FAILED`: terminal state with `errorMessage`
+
+Retry endpoint re-queues failed notes and re-enters pipeline from `TRANSCRIBING`.
+
+## Share Link Security
+
+- Share links are generated as opaque random tokens.
+- Only hashed token values (`tokenHash`) are stored in database.
+- Link lookup is performed by hash comparison, never by raw token persistence.
+- Every link has explicit `expiresAt`.
+- Optional scoped content flags: `allowSummary`, `allowTranscript`.
+- Share links are revocable via authenticated endpoint.
+
+## External Integrations
+
+- Brevo: transactional email sharing
+- Twilio: WhatsApp share delivery
+- Discord webhook: event notifications
+- OpenAI Whisper: transcription generation
+- S3-compatible storage gateway: avatar/audio object storage
+
+## Error Handling Strategy
+
+- NestJS HTTP exceptions with canonical status codes
+- Validation errors returned as `400 Bad Request`
+- AuthN failures as `401`, AuthZ failures as `403`
+- Missing resources as `404`
+- Rate-limit breaches as `429`
+- Pipeline/integration failures captured on note with `FAILED` + `errorMessage`
+- Consistent JSON error envelope at controller boundaries
+
+## Security Measures
+
+- Access token + rotating refresh token model
+- Refresh token hashing in persistence
+- Role-based access control for admin operations
+- Input validation via DTO decorators
+- Password hashing with bcrypt
+- HTTP-only refresh cookie handling
+- Token expiration checks for refresh/share/reset flows
+- Request rate limiting for sensitive routes
+
+## Observability
+
+- Structured application logs for request lifecycle and errors
+- Request correlation using request identifier strategy
+- `/health` endpoint for liveness checks
+- Admin jobs endpoint for operational visibility
+- Error context persisted for failed note pipeline states
+
+## Scaling Strategy
+
+- Keep API layer stateless; persist session artifacts in DB
+- Horizontal scale API replicas behind load balancer
+- Offload long-running transcription/summarization to queue workers
+- Isolate worker pool from request/response path
+- Use managed PostgreSQL with read replica strategy as query load grows
+- Use object storage and CDN for media delivery
+- Add per-feature caches for high-read public/blog endpoints
+
+## CI Strategy for Tests and Migrations
+
+- Run install + lint + unit tests for API and frontend on pull requests
+- Run API and frontend e2e suites on merge to main
+- Apply Prisma migration checks in CI before deploy
+- Use dedicated CI test database for `test:api:e2e:ci`
+- Block deployment on failed migrations/tests
+- Deploy backend and frontend artifacts after green pipeline


### PR DESCRIPTION
### Motivation
- Provide a complete, developer-ready reference for the BlaBlaNote monorepo covering setup, architecture, data model, API surface, pipelines, and troubleshooting.  
- Deliver machine-readable architecture artifacts and Mermaid diagrams to speed onboarding and design reviews.  
- Ship public-facing marketing and SEO-ready copy to bootstrap the SaaS landing site and content strategy.

### Description
- Updated `BlaBlaNote/README.md` with product overview, full feature list, Nx monorepo structure, a comprehensive environment variable table, local run steps, Prisma commands, Swagger pointer, auth flow summary, storage notes, testing commands, and troubleshooting guidance.  
- Reworked `BlaBlaNote/TECHNICAL_SPECIFICATION.md` to document backend modules, responsibilities, database schema and relations, API segmentation (public/protected/admin), transcription pipeline lifecycle, share link security, external integrations, error handling, security measures, observability, scaling strategy, and CI guidance.  
- Added `BlaBlaNote/API_REFERENCE.md` with grouped endpoint tables for Auth, Notes, Projects, Tags, Profile, Share, Admin, and Blog plus representative request/response examples and an error code mapping.  
- Added `BlaBlaNote/ARCHITECTURE_DIAGRAMS.md` with Mermaid system context, NestJS module dependency diagram, create-note and refresh-token rotation sequence diagrams, and a high-level ER diagram, and added `BlaBlaNote/MARKETING_SITE.md` containing landing page copy, pricing, FAQ, SEO essentials, blog strategy, and tone/style guidelines.

### Testing
- Ran `cd BlaBlaNote && yarn -s prettier --write README.md TECHNICAL_SPECIFICATION.md API_REFERENCE.md ARCHITECTURE_DIAGRAMS.md MARKETING_SITE.md` to apply formatting changes and the command completed successfully.  
- Verified formatting with `cd BlaBlaNote && yarn -s prettier --check README.md TECHNICAL_SPECIFICATION.md API_REFERENCE.md ARCHITECTURE_DIAGRAMS.md MARKETING_SITE.md` and the check passed.  
- No runtime code changes were made and no backend/frontend unit or e2e test suites were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a25d089ce08320b5e4d10f36f99764)